### PR TITLE
[TRYC-122] 연결계좌 추가하기 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     // rest docs
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+
+    // security
+    implementation 'org.springframework.security:spring-security-core'
 }
 
 bootJar {

--- a/src/main/java/com/dangdang/server/controller/ConnectionAccountDatabaseController.java
+++ b/src/main/java/com/dangdang/server/controller/ConnectionAccountDatabaseController.java
@@ -1,0 +1,41 @@
+package com.dangdang.server.controller;
+
+import com.dangdang.server.domain.connectionAccount.application.ConnectionAccountDatabaseService;
+import com.dangdang.server.domain.connectionAccount.dto.AddConnectionAccountRequest;
+import com.dangdang.server.domain.member.domain.entity.Member;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 외부 API 연동 제외
+ */
+@RestController
+@RequestMapping("/connection-account")
+public class ConnectionAccountDatabaseController {
+
+  private final ConnectionAccountDatabaseService connectionAccountDataBaseService;
+
+  public ConnectionAccountDatabaseController(
+      ConnectionAccountDatabaseService connectionAccountDataBaseService) {
+    this.connectionAccountDataBaseService = connectionAccountDataBaseService;
+  }
+
+  /**
+   * 연결계좌 추가 API
+   */
+  @PostMapping("")
+  public ResponseEntity<HttpStatus> addConnectionAccount(Authentication authentication,
+      @RequestBody AddConnectionAccountRequest addConnectionAccountRequest) {
+    Long memberId = ((Member) authentication.getPrincipal()).getId();
+
+    connectionAccountDataBaseService.addConnectionAccount(memberId,
+        addConnectionAccountRequest);
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/bankAccount/domain/BankAccountRepository.java
+++ b/src/main/java/com/dangdang/server/domain/bankAccount/domain/BankAccountRepository.java
@@ -1,0 +1,10 @@
+package com.dangdang.server.domain.bankAccount.domain;
+
+import com.dangdang.server.domain.bankAccount.domain.entity.BankAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BankAccountRepository extends JpaRepository<BankAccount, Long> {
+
+}

--- a/src/main/java/com/dangdang/server/domain/bankAccount/domain/entity/BankAccount.java
+++ b/src/main/java/com/dangdang/server/domain/bankAccount/domain/entity/BankAccount.java
@@ -1,6 +1,7 @@
 package com.dangdang.server.domain.bankAccount.domain.entity;
 
 import com.dangdang.server.domain.common.BaseEntity;
+import com.dangdang.server.domain.common.StatusType;
 import com.dangdang.server.domain.payMember.domain.entity.PayMember;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -39,4 +40,19 @@ public class BankAccount extends BaseEntity {
   protected BankAccount() {
   }
 
+  public BankAccount(String accountNumber, String bank, Integer balance, PayMember payMember) {
+    this.accountNumber = accountNumber;
+    this.bank = bank;
+    this.balance = balance;
+    this.payMember = payMember;
+  }
+
+  public BankAccount(String accountNumber, String bank, Integer balance, PayMember payMember,
+      StatusType statusType) {
+    this.accountNumber = accountNumber;
+    this.bank = bank;
+    this.balance = balance;
+    this.payMember = payMember;
+    this.status = statusType;
+  }
 }

--- a/src/main/java/com/dangdang/server/domain/bankAccount/domain/entity/BankAccount.java
+++ b/src/main/java/com/dangdang/server/domain/bankAccount/domain/entity/BankAccount.java
@@ -6,6 +6,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -17,7 +18,7 @@ import org.hibernate.annotations.ColumnDefault;
 public class BankAccount extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "bank_account_id")
   private Long id;
 

--- a/src/main/java/com/dangdang/server/domain/bankAccount/domain/entity/BankAccount.java
+++ b/src/main/java/com/dangdang/server/domain/bankAccount/domain/entity/BankAccount.java
@@ -10,6 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.Getter;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -27,7 +28,8 @@ public class BankAccount extends BaseEntity {
   private String bank;
 
   @Column(columnDefinition = "INT UNSIGNED")
-  private Integer balance;
+  @ColumnDefault("0")
+  private Integer balance = 0;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "pay_member_id")

--- a/src/main/java/com/dangdang/server/domain/bankAccount/exception/InactiveBankAccountException.java
+++ b/src/main/java/com/dangdang/server/domain/bankAccount/exception/InactiveBankAccountException.java
@@ -1,0 +1,11 @@
+package com.dangdang.server.domain.bankAccount.exception;
+
+import com.dangdang.server.global.exception.BusinessException;
+import com.dangdang.server.global.exception.ExceptionCode;
+
+public class InactiveBankAccountException extends BusinessException {
+
+  public InactiveBankAccountException(ExceptionCode exceptionCode) {
+    super(exceptionCode);
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/chat/domain/entity/Chat.java
+++ b/src/main/java/com/dangdang/server/domain/chat/domain/entity/Chat.java
@@ -4,6 +4,7 @@ import com.dangdang.server.domain.common.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.Getter;
 
@@ -12,7 +13,7 @@ import lombok.Getter;
 public class Chat extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "chat_id")
   private Long id;
 

--- a/src/main/java/com/dangdang/server/domain/chatMessage/domain/entity/ChatMessage.java
+++ b/src/main/java/com/dangdang/server/domain/chatMessage/domain/entity/ChatMessage.java
@@ -4,6 +4,7 @@ import com.dangdang.server.domain.common.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.Getter;
 
@@ -12,7 +13,7 @@ import lombok.Getter;
 public class ChatMessage extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "chat_message_id")
   private Long id;
 

--- a/src/main/java/com/dangdang/server/domain/common/BaseEntity.java
+++ b/src/main/java/com/dangdang/server/domain/common/BaseEntity.java
@@ -17,6 +17,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
+  @Column
+  @Enumerated(EnumType.STRING)
+  @ColumnDefault("'ACTIVE'")
+  protected StatusType status = StatusType.ACTIVE;
+
   @CreatedDate
   @Column(updatable = false)
   private LocalDateTime createdAt;
@@ -24,9 +29,4 @@ public abstract class BaseEntity {
   @LastModifiedDate
   @Column
   private LocalDateTime updatedAt;
-
-  @Column
-  @Enumerated(EnumType.STRING)
-  @ColumnDefault("'ACTIVE'")
-  private StatusType status = StatusType.ACTIVE;
 }

--- a/src/main/java/com/dangdang/server/domain/connectionAccount/application/ConnectionAccountDatabaseService.java
+++ b/src/main/java/com/dangdang/server/domain/connectionAccount/application/ConnectionAccountDatabaseService.java
@@ -1,0 +1,56 @@
+package com.dangdang.server.domain.connectionAccount.application;
+
+import static com.dangdang.server.global.exception.ExceptionCode.BANK_ACCOUNT_INACTIVE;
+import static com.dangdang.server.global.exception.ExceptionCode.BANK_ACCOUNT_NOT_FOUND;
+import static com.dangdang.server.global.exception.ExceptionCode.PAY_MEMBER_NOT_FOUND;
+
+import com.dangdang.server.domain.bankAccount.domain.BankAccountRepository;
+import com.dangdang.server.domain.bankAccount.domain.entity.BankAccount;
+import com.dangdang.server.domain.bankAccount.exception.InactiveBankAccountException;
+import com.dangdang.server.domain.common.StatusType;
+import com.dangdang.server.domain.connectionAccount.domain.ConnectionAccountRepository;
+import com.dangdang.server.domain.connectionAccount.domain.entity.ConnectionAccount;
+import com.dangdang.server.domain.connectionAccount.dto.AddConnectionAccountRequest;
+import com.dangdang.server.domain.connectionAccount.exception.EmptyResultException;
+import com.dangdang.server.domain.payMember.domain.entity.PayMember;
+import com.dangdang.server.domain.payMember.domain.entity.PayMemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ConnectionAccountDatabaseService {
+
+  private final ConnectionAccountRepository connectionAccountRepository;
+  private final PayMemberRepository payMemberRepository;
+  private final BankAccountRepository bankAccountRepository;
+
+  public ConnectionAccountDatabaseService(ConnectionAccountRepository connectionAccountRepository,
+      PayMemberRepository payMemberRepository, BankAccountRepository bankAccountRepository) {
+    this.connectionAccountRepository = connectionAccountRepository;
+    this.payMemberRepository = payMemberRepository;
+    this.bankAccountRepository = bankAccountRepository;
+  }
+
+  /**
+   * 연결 계좌 추가
+   */
+  @Transactional
+  public ConnectionAccount addConnectionAccount(Long memberId,
+      AddConnectionAccountRequest addConnectionAccountRequest) {
+    PayMember payMember = payMemberRepository.findByMember_Id(memberId)
+        .orElseThrow(() -> new EmptyResultException(PAY_MEMBER_NOT_FOUND));
+
+    BankAccount bankAccount = bankAccountRepository.findById(
+            addConnectionAccountRequest.getBankAccountId())
+        .orElseThrow(() -> new EmptyResultException(BANK_ACCOUNT_NOT_FOUND));
+
+    if (bankAccount.getStatus() == StatusType.INACTIVE) {
+      throw new InactiveBankAccountException(BANK_ACCOUNT_INACTIVE);
+    }
+
+    ConnectionAccount connectionAccount = AddConnectionAccountRequest.toConnectionAccount(payMember,
+        bankAccount);
+    return connectionAccountRepository.save(connectionAccount);
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/connectionAccount/domain/ConnectionAccountRepository.java
+++ b/src/main/java/com/dangdang/server/domain/connectionAccount/domain/ConnectionAccountRepository.java
@@ -1,0 +1,10 @@
+package com.dangdang.server.domain.connectionAccount.domain;
+
+import com.dangdang.server.domain.connectionAccount.domain.entity.ConnectionAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConnectionAccountRepository extends JpaRepository<ConnectionAccount, Long> {
+
+}

--- a/src/main/java/com/dangdang/server/domain/connectionAccount/domain/entity/ConnectionAccount.java
+++ b/src/main/java/com/dangdang/server/domain/connectionAccount/domain/entity/ConnectionAccount.java
@@ -7,6 +7,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -17,7 +18,7 @@ import lombok.Getter;
 public class ConnectionAccount extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "connection_account_id")
   private Long id;
 

--- a/src/main/java/com/dangdang/server/domain/connectionAccount/domain/entity/ConnectionAccount.java
+++ b/src/main/java/com/dangdang/server/domain/connectionAccount/domain/entity/ConnectionAccount.java
@@ -30,4 +30,11 @@ public class ConnectionAccount extends BaseEntity {
   @JoinColumn(name = "bank_account_id")
   private BankAccount bankAccount;
 
+  protected ConnectionAccount() {
+  }
+
+  public ConnectionAccount(PayMember payMember, BankAccount bankAccount) {
+    this.payMember = payMember;
+    this.bankAccount = bankAccount;
+  }
 }

--- a/src/main/java/com/dangdang/server/domain/connectionAccount/dto/AddConnectionAccountRequest.java
+++ b/src/main/java/com/dangdang/server/domain/connectionAccount/dto/AddConnectionAccountRequest.java
@@ -1,0 +1,24 @@
+package com.dangdang.server.domain.connectionAccount.dto;
+
+import com.dangdang.server.domain.bankAccount.domain.entity.BankAccount;
+import com.dangdang.server.domain.connectionAccount.domain.entity.ConnectionAccount;
+import com.dangdang.server.domain.payMember.domain.entity.PayMember;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+@Getter
+public class AddConnectionAccountRequest {
+
+  private Long bankAccountId;
+
+  @JsonCreator
+  public AddConnectionAccountRequest(Long bankAccountId) {
+    this.bankAccountId = bankAccountId;
+  }
+
+  public static ConnectionAccount toConnectionAccount(PayMember payMember,
+      BankAccount bankAccount) {
+
+    return new ConnectionAccount(payMember, bankAccount);
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/connectionAccount/exception/EmptyResultException.java
+++ b/src/main/java/com/dangdang/server/domain/connectionAccount/exception/EmptyResultException.java
@@ -1,0 +1,11 @@
+package com.dangdang.server.domain.connectionAccount.exception;
+
+import com.dangdang.server.global.exception.BusinessException;
+import com.dangdang.server.global.exception.ExceptionCode;
+
+public class EmptyResultException extends BusinessException {
+
+  public EmptyResultException(ExceptionCode exceptionCode) {
+    super(exceptionCode);
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/dangdang/server/domain/member/domain/entity/Member.java
@@ -4,6 +4,7 @@ import com.dangdang.server.domain.common.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import lombok.Getter;
 public class Member extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "member_id")
   private Long id;
 
@@ -28,5 +29,10 @@ public class Member extends BaseEntity {
   private String profileImgUrl;
 
   protected Member() {
+  }
+
+  public Member(String nickname, String phoneNumber) {
+    this.nickname = nickname;
+    this.phoneNumber = phoneNumber;
   }
 }

--- a/src/main/java/com/dangdang/server/domain/member/domain/entity/MemberRepository.java
+++ b/src/main/java/com/dangdang/server/domain/member/domain/entity/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.dangdang.server.domain.member.domain.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/dangdang/server/domain/memberTown/domain/entity/MemberTown.java
+++ b/src/main/java/com/dangdang/server/domain/memberTown/domain/entity/MemberTown.java
@@ -9,6 +9,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -19,7 +20,7 @@ import lombok.Getter;
 public class MemberTown extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "member_town_id")
   private Long id;
 

--- a/src/main/java/com/dangdang/server/domain/payMember/domain/entity/PayMember.java
+++ b/src/main/java/com/dangdang/server/domain/payMember/domain/entity/PayMember.java
@@ -6,6 +6,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
@@ -17,7 +18,7 @@ import org.hibernate.annotations.ColumnDefault;
 public class PayMember extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "pay_user_id")
   private Long id;
 

--- a/src/main/java/com/dangdang/server/domain/payMember/domain/entity/PayMember.java
+++ b/src/main/java/com/dangdang/server/domain/payMember/domain/entity/PayMember.java
@@ -31,7 +31,7 @@ public class PayMember extends BaseEntity {
 
   @Column(columnDefinition = "INT UNSIGNED")
   @ColumnDefault("5")
-  private Integer fee_count = 5;
+  private Integer feeCount = 5;
 
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id")
@@ -40,4 +40,8 @@ public class PayMember extends BaseEntity {
   protected PayMember() {
   }
 
+  public PayMember(String password, Member member) {
+    this.password = password;
+    this.member = member;
+  }
 }

--- a/src/main/java/com/dangdang/server/domain/payMember/domain/entity/PayMemberRepository.java
+++ b/src/main/java/com/dangdang/server/domain/payMember/domain/entity/PayMemberRepository.java
@@ -1,0 +1,12 @@
+package com.dangdang.server.domain.payMember.domain.entity;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PayMemberRepository extends JpaRepository<PayMember, Long> {
+
+  Optional<PayMember> findByMember_Id(@Param(value = "memberId") Long memberId);
+}

--- a/src/main/java/com/dangdang/server/domain/payUsageHistory/domain/entity/PayUsageHistory.java
+++ b/src/main/java/com/dangdang/server/domain/payUsageHistory/domain/entity/PayUsageHistory.java
@@ -7,6 +7,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -18,7 +19,7 @@ import org.hibernate.annotations.ColumnDefault;
 public class PayUsageHistory extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "pay_usage_history_id")
   private Long id;
 

--- a/src/main/java/com/dangdang/server/domain/post/domain/entity/Post.java
+++ b/src/main/java/com/dangdang/server/domain/post/domain/entity/Post.java
@@ -11,6 +11,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -22,7 +23,7 @@ import org.hibernate.annotations.ColumnDefault;
 public class Post extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "post_id")
   private Long id;
 

--- a/src/main/java/com/dangdang/server/domain/postImage/domain/entity/PostImage.java
+++ b/src/main/java/com/dangdang/server/domain/postImage/domain/entity/PostImage.java
@@ -6,6 +6,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
@@ -17,7 +18,7 @@ import lombok.Getter;
 public class PostImage extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "post_image_id")
   private Long id;
 

--- a/src/main/java/com/dangdang/server/domain/review/domain/entity/Review.java
+++ b/src/main/java/com/dangdang/server/domain/review/domain/entity/Review.java
@@ -7,6 +7,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -17,7 +18,7 @@ import lombok.Getter;
 public class Review extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "review_id")
   private Long id;
 

--- a/src/main/java/com/dangdang/server/domain/town/domain/entity/Town.java
+++ b/src/main/java/com/dangdang/server/domain/town/domain/entity/Town.java
@@ -5,8 +5,8 @@ import java.math.BigDecimal;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import lombok.Cleanup;
 import lombok.Getter;
 
 @Entity
@@ -14,7 +14,7 @@ import lombok.Getter;
 public class Town extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "town_id")
   private Long id;
 

--- a/src/main/java/com/dangdang/server/global/exception/ExceptionCode.java
+++ b/src/main/java/com/dangdang/server/global/exception/ExceptionCode.java
@@ -1,7 +1,13 @@
 package com.dangdang.server.global.exception;
 
+import org.springframework.http.HttpStatus;
+
 public enum ExceptionCode {
-  ;
+
+  // pay
+  BANK_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "은행 계좌를 찾지 못했습니다."),
+  BANK_ACCOUNT_INACTIVE(HttpStatus.BAD_REQUEST.value(), "사용할 수 없는 계좌입니다."),
+  PAY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "당근페이 유저를 찾지 못했습니다.");
 
   int status;
   String message;

--- a/src/test/java/com/dangdang/server/controller/ConnectionAccountDatabaseControllerTest.java
+++ b/src/test/java/com/dangdang/server/controller/ConnectionAccountDatabaseControllerTest.java
@@ -1,0 +1,52 @@
+package com.dangdang.server.controller;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+class ConnectionAccountDatabaseControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  void addConnectionAccount() throws Exception {
+    mockMvc.perform(
+            post("/connection-account")
+//                .header("authentication", )
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        )
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "ConnectionAccountDatabaseController/addConnectionAccount",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+//                requestHeaders(
+//                    headerWithName("authentication").description("jwt header")
+//                ),
+                requestFields(
+                    fieldWithPath("bankAccountId").type(JsonFieldType.NUMBER).description("은행계좌 Id")
+                )
+            )
+        );
+  }
+}

--- a/src/test/java/com/dangdang/server/domain/connectionAccount/application/ConnectionAccountDatabaseServiceTest.java
+++ b/src/test/java/com/dangdang/server/domain/connectionAccount/application/ConnectionAccountDatabaseServiceTest.java
@@ -1,0 +1,101 @@
+package com.dangdang.server.domain.connectionAccount.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.dangdang.server.domain.bankAccount.domain.BankAccountRepository;
+import com.dangdang.server.domain.bankAccount.domain.entity.BankAccount;
+import com.dangdang.server.domain.bankAccount.exception.InactiveBankAccountException;
+import com.dangdang.server.domain.common.StatusType;
+import com.dangdang.server.domain.connectionAccount.domain.ConnectionAccountRepository;
+import com.dangdang.server.domain.connectionAccount.domain.entity.ConnectionAccount;
+import com.dangdang.server.domain.connectionAccount.dto.AddConnectionAccountRequest;
+import com.dangdang.server.domain.member.domain.entity.Member;
+import com.dangdang.server.domain.member.domain.entity.MemberRepository;
+import com.dangdang.server.domain.payMember.domain.entity.PayMember;
+import com.dangdang.server.domain.payMember.domain.entity.PayMemberRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+@DisplayName("연결계좌 DB 테스트")
+class ConnectionAccountDatabaseServiceTest {
+
+  static Member member;
+  static PayMember payMember;
+  static List<BankAccount> bankAccounts;
+
+  @Autowired
+  MemberRepository memberRepository;
+  @Autowired
+  PayMemberRepository payMemberRepository;
+  @Autowired
+  BankAccountRepository bankAccountRepository;
+  @Autowired
+  ConnectionAccountRepository connectionAccountRepository;
+  @Autowired
+  ConnectionAccountDatabaseService connectionAccountDataBaseService;
+
+  @BeforeEach
+  void createPayMemberAndBankAccounts() {
+    member = new Member("예지 테스트 유저", "01012341234");
+    memberRepository.save(member);
+
+    String password = "password123";
+    payMember = new PayMember(password, member);
+    payMemberRepository.save(payMember);
+
+    BankAccount bankAccount1 = new BankAccount("12383461723", "신한은행", 500000, payMember);
+    BankAccount bankAccount2 = new BankAccount("34511234235", "우리은행", 40000, payMember);
+    BankAccount bankAccount3 = new BankAccount("01290947732", "케이뱅크", 248200, payMember);
+
+    bankAccounts = List.of(bankAccount1, bankAccount2, bankAccount3);
+    bankAccountRepository.saveAll(bankAccounts);
+  }
+
+  @TestInstance(Lifecycle.PER_CLASS)
+  @Nested
+  @DisplayName("연결계좌를 새로 추가할 때")
+  class addConnectionAccount {
+
+    @Test
+    @DisplayName("성공한다면 bankAccountId와 payMemberId가 저장된다.")
+    void successAdd() {
+      for (BankAccount bankAccount : bankAccounts) {
+        AddConnectionAccountRequest addConnectionAccountRequest = new AddConnectionAccountRequest(
+            bankAccount.getId());
+
+        ConnectionAccount connectionAccount = connectionAccountDataBaseService.addConnectionAccount(
+            payMember.getId(), addConnectionAccountRequest);
+
+        assertThat(connectionAccount.getBankAccount().getId()).isEqualTo(bankAccount.getId());
+        assertThat(connectionAccount.getPayMember().getId()).isEqualTo(payMember.getId());
+      }
+    }
+
+    @Test
+    @DisplayName("사용 불가능 계좌일 경우 추가할 수 없다.")
+    void failAdd() {
+      BankAccount bankAccount = new BankAccount("12383461723", "신한은행", 500000, payMember,
+          StatusType.INACTIVE);
+      bankAccountRepository.save(bankAccount);
+
+      AddConnectionAccountRequest addConnectionAccountRequest = new AddConnectionAccountRequest(
+          bankAccount.getId());
+      Long payMemberId = payMember.getId();
+
+      assertThrows(InactiveBankAccountException.class,
+          () -> connectionAccountDataBaseService.addConnectionAccount(payMemberId,
+              addConnectionAccountRequest));
+    }
+  }
+}

--- a/src/test/java/com/dangdang/server/domain/payMember/domain/entity/PayMemberRepositoryTest.java
+++ b/src/test/java/com/dangdang/server/domain/payMember/domain/entity/PayMemberRepositoryTest.java
@@ -1,0 +1,35 @@
+package com.dangdang.server.domain.payMember.domain.entity;
+
+import com.dangdang.server.domain.member.domain.entity.Member;
+import com.dangdang.server.domain.member.domain.entity.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class PayMemberRepositoryTest {
+
+  @Autowired
+  PayMemberRepository payMemberRepository;
+  @Autowired
+  MemberRepository memberRepository;
+
+  @Test
+  @DisplayName("memberId FK값을 활용해서 PayMember 엔티티를 가져올 수 있다.")
+  void findByMember_Id() {
+    Member member = new Member("예지 테스트 유저", "01012341234");
+    memberRepository.save(member);
+
+    String password = "password123";
+    PayMember payMember = new PayMember(password, member);
+    payMemberRepository.save(payMember);
+
+    PayMember findPayMember = payMemberRepository.findByMember_Id(member.getId()).get();
+
+    Assertions.assertThat(findPayMember.getMember().getId()).isEqualTo(member.getId());
+  }
+}


### PR DESCRIPTION
### 변경 내용 요약
연결계좌 추가하기 API 구현

### 작업한 내용
- bankAccount 테이블은 은행 계좌 정보입니다. (실제로는 외부에 있으나 내부 DB에 존재한다고 가정)
- connectionAccount 테이블은 당근페이 내부의 유저 별 연결계좌 정보입니다.

**성공**

**Response Status Code**

- `200 OK`

**실패**

**Response Status Code, Body**

- `404 NOT FOUND`

```json
{
    "message": "은행 계좌를 찾지 못했습니다."
}
```

```json
{
    "message": "당근페이 유저를 찾지 못했습니다."
}
```

- `400 BAD REQUEST`
```json
{
    "message": "사용할 수 없는 계좌입니다."
}
```

### 관련 링크
- [지라 티켓](https://cloudwi.atlassian.net/browse/TRYC-122?atlOrigin=eyJpIjoiNzI5YmVhMjhmN2RkNDhiZDgzNzEzMDM3MzdkZDQwYWQiLCJwIjoiaiJ9) <!-- 괄호 안에 지라 티켓 링크 넣어주세요. -->

### 기타 사항
controllerTest는 member 도메인쪽 로직과 합쳐진 후 작성 예정입니다.
