### PR TITLE
[TRYC-50] 상세 게시글 조회 구현1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    //validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/dangdang/server/domain/common/BaseEntity.java
+++ b/src/main/java/com/dangdang/server/domain/common/BaseEntity.java
@@ -28,5 +28,5 @@ public abstract class BaseEntity {
   @Column
   @Enumerated(EnumType.STRING)
   @ColumnDefault("'ACTIVE'")
-  private StatusType status = StatusType.ACTIVE;
+  protected StatusType status = StatusType.ACTIVE;
 }

--- a/src/main/java/com/dangdang/server/domain/common/StatusType.java
+++ b/src/main/java/com/dangdang/server/domain/common/StatusType.java
@@ -2,5 +2,6 @@ package com.dangdang.server.domain.common;
 
 public enum StatusType {
 
-  ACTIVE, INACTIVE
+  ACTIVE, INACTIVE,
+  RESERVED, SELLING, COMPLETED //Post 상태값
 }

--- a/src/main/java/com/dangdang/server/domain/post/application/PostService.java
+++ b/src/main/java/com/dangdang/server/domain/post/application/PostService.java
@@ -8,10 +8,12 @@ import com.dangdang.server.domain.post.domain.PostRepository;
 import com.dangdang.server.domain.post.domain.entity.Post;
 import com.dangdang.server.domain.post.dto.request.PostSaveRequest;
 import com.dangdang.server.domain.post.dto.request.PostSliceRequest;
+import com.dangdang.server.domain.post.dto.response.PostDetailResponse;
 import com.dangdang.server.domain.post.dto.response.PostResponse;
 import com.dangdang.server.domain.post.dto.response.PostSliceResponse;
 import com.dangdang.server.domain.post.dto.response.PostsSliceResponse;
 import com.dangdang.server.domain.post.exception.PostNotFoundException;
+import com.dangdang.server.domain.postImage.application.PostImageService;
 import com.dangdang.server.domain.town.domain.TownRepository;
 import com.dangdang.server.domain.town.domain.entity.Town;
 import com.dangdang.server.domain.town.exception.TownNotFoundException;
@@ -28,10 +30,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
   private final PostRepository postRepository;
+  private final PostImageService postImageService;
   private final TownRepository townRepository;
 
-  public PostService(PostRepository postRepository, TownRepository townRepository) {
+  public PostService(PostRepository postRepository, PostImageService postImageService,
+      TownRepository townRepository) {
     this.postRepository = postRepository;
+    this.postImageService = postImageService;
     this.townRepository = townRepository;
   }
 
@@ -54,19 +59,23 @@ public class PostService {
     );
   }
 
-  public PostResponse findPostById(Long postId) {
-    Post foundPost = postRepository.findById(postId)
-        .orElseThrow(() -> new PostNotFoundException(POST_NOT_FOUND));
-
-    return PostResponse.from(foundPost);
-  }
-
   @Transactional
   public PostResponse savePost(PostSaveRequest postSaveRequest, Member loginMember) {
     Town foundTown = townRepository.findTownByName(postSaveRequest.getTownName())
         .orElseThrow(() -> new TownNotFoundException(TOWN_NOT_FOUND));
     Post post = PostSaveRequest.toPost(postSaveRequest, loginMember, foundTown);
     Post savedPost = postRepository.save(post);
+    postImageService.savePostImage(savedPost, postSaveRequest.getPostImageRequest());
+
     return PostResponse.from(savedPost);
+  }
+
+  public PostDetailResponse findPostDetailById(Long postId) {
+    Post foundPost = postRepository.findPostDetailById(postId)
+        .orElseThrow(() -> new PostNotFoundException(POST_NOT_FOUND));
+
+    List<String> postImageUrls = postImageService.findPostImagesByPostId(postId);
+
+    return PostDetailResponse.from(foundPost, postImageUrls);
   }
 }

--- a/src/main/java/com/dangdang/server/domain/post/domain/Category.java
+++ b/src/main/java/com/dangdang/server/domain/post/domain/Category.java
@@ -1,5 +1,31 @@
 package com.dangdang.server.domain.post.domain;
 
+import static com.dangdang.server.global.exception.ExceptionCode.CATEGORY_NOT_FOUND;
+
+import com.dangdang.server.domain.post.exception.CategoryNotFoundException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.stream.Stream;
+
 public enum Category {
-  가전제품,
+  디지털기기("DigitalDevices"), 생활가전("HouseholdAppliances");
+
+  private final String name;
+
+  Category(String name) {
+    this.name = name;
+  }
+
+  @JsonCreator
+  public static Category selectCategory(String name) {
+    return Stream.of(values())
+        .filter(category -> category.name.equals(name))
+        .findFirst()
+        .orElseThrow(() -> new CategoryNotFoundException(CATEGORY_NOT_FOUND));
+  }
+
+  @JsonValue
+  public String getName() {
+    return name;
+  }
 }

--- a/src/main/java/com/dangdang/server/domain/post/domain/PostRepository.java
+++ b/src/main/java/com/dangdang/server/domain/post/domain/PostRepository.java
@@ -2,6 +2,7 @@ package com.dangdang.server.domain.post.domain;
 
 import com.dangdang.server.domain.post.domain.entity.Post;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +12,9 @@ import org.springframework.data.repository.query.Param;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
   @Query(value = "select p from Post p join fetch p.town where p.town.id in (:adjacency)")
-  public Slice<Post> findPostsByTownIdFetchJoinSortByCreatedAt(
+  Slice<Post> findPostsByTownIdFetchJoinSortByCreatedAt(
       @Param("adjacency") List<Long> adjacency, Pageable pageable);
+
+  @Query(value = "select p from Post p join fetch p.member where p.id = :postId")
+  Optional<Post> findPostDetailById(@Param("postId") Long postId);
 }

--- a/src/main/java/com/dangdang/server/domain/post/domain/entity/Post.java
+++ b/src/main/java/com/dangdang/server/domain/post/domain/entity/Post.java
@@ -1,6 +1,7 @@
 package com.dangdang.server.domain.post.domain.entity;
 
 import com.dangdang.server.domain.common.BaseEntity;
+import com.dangdang.server.domain.common.StatusType;
 import com.dangdang.server.domain.member.domain.entity.Member;
 import com.dangdang.server.domain.post.domain.Category;
 import com.dangdang.server.domain.town.domain.entity.Town;
@@ -71,7 +72,7 @@ public class Post extends BaseEntity {
 
   public Post(String title, String content, Category category, Integer price,
       String desiredPlaceName, BigDecimal desiredPlaceLongitude, BigDecimal desiredPlaceLatitude,
-      Integer view, Boolean sharing, Member member, Town town) {
+      Integer view, Boolean sharing, Member member, Town town, StatusType statusType) {
     this.title = title;
     this.content = content;
     this.category = category;
@@ -83,5 +84,10 @@ public class Post extends BaseEntity {
     this.sharing = sharing;
     this.member = member;
     this.town = town;
+    super.status = statusType;
+  }
+
+  public String getTownName() {
+    return town.getName();
   }
 }

--- a/src/main/java/com/dangdang/server/domain/post/domain/entity/Post.java
+++ b/src/main/java/com/dangdang/server/domain/post/domain/entity/Post.java
@@ -37,9 +37,8 @@ public class Post extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private Category category;
 
-  @Column(columnDefinition = "INT UNSIGNED", nullable = false)
-  @ColumnDefault("0")
-  private Integer price = 0;
+  @Column(columnDefinition = "INT UNSIGNED")
+  private Integer price;
 
   @Column(length = 100)
   private String desiredPlaceName;

--- a/src/main/java/com/dangdang/server/domain/post/dto/request/PostSaveRequest.java
+++ b/src/main/java/com/dangdang/server/domain/post/dto/request/PostSaveRequest.java
@@ -4,6 +4,7 @@ import com.dangdang.server.domain.common.StatusType;
 import com.dangdang.server.domain.member.domain.entity.Member;
 import com.dangdang.server.domain.post.domain.Category;
 import com.dangdang.server.domain.post.domain.entity.Post;
+import com.dangdang.server.domain.postImage.dto.PostImageRequest;
 import com.dangdang.server.domain.town.domain.entity.Town;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;
@@ -48,10 +49,13 @@ public class PostSaveRequest {
   @Size(max = 10)
   private String townName;
 
+  @Size(max = 10)
+  private PostImageRequest postImageRequest;
+
   @JsonCreator
   public PostSaveRequest(String title, String content, Category category, Integer price,
       String desiredPlaceName, BigDecimal desiredPlaceLongitude, BigDecimal desiredPlaceLatitude,
-      Boolean sharing, String townName) {
+      Boolean sharing, String townName, PostImageRequest postImageRequest) {
     this.title = title;
     this.content = content;
     this.category = category;
@@ -62,6 +66,7 @@ public class PostSaveRequest {
     this.view = 0;
     this.sharing = sharing;
     this.townName = townName;
+    this.postImageRequest = postImageRequest;
   }
 
   public static Post toPost(PostSaveRequest postSaveRequest, Member loginMember, Town town) {

--- a/src/main/java/com/dangdang/server/domain/post/dto/request/PostSaveRequest.java
+++ b/src/main/java/com/dangdang/server/domain/post/dto/request/PostSaveRequest.java
@@ -7,20 +7,45 @@ import com.dangdang.server.domain.post.domain.entity.Post;
 import com.dangdang.server.domain.town.domain.entity.Town;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+import javax.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class PostSaveRequest {
 
+  @NotNull
+  @Max(value = 255)
   private String title;
+
+  @NotNull
+  @Max(value = 1000)
   private String content;
+
+  @NotNull
   private Category category;
+
+  @Min(value = 0)
   private Integer price;
+
+  @Size(max = 100)
   private String desiredPlaceName;
+
   private BigDecimal desiredPlaceLongitude;
+
   private BigDecimal desiredPlaceLatitude;
+
+  @Null
   private Integer view;
+
+  @NotNull
   private Boolean sharing;
+
+  @NotNull
+  @Size(max = 10)
   private String townName;
 
   @JsonCreator

--- a/src/main/java/com/dangdang/server/domain/post/dto/request/PostSaveRequest.java
+++ b/src/main/java/com/dangdang/server/domain/post/dto/request/PostSaveRequest.java
@@ -1,0 +1,48 @@
+package com.dangdang.server.domain.post.dto.request;
+
+import com.dangdang.server.domain.common.StatusType;
+import com.dangdang.server.domain.member.domain.entity.Member;
+import com.dangdang.server.domain.post.domain.Category;
+import com.dangdang.server.domain.post.domain.entity.Post;
+import com.dangdang.server.domain.town.domain.entity.Town;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.math.BigDecimal;
+import lombok.Getter;
+
+@Getter
+public class PostSaveRequest {
+
+  private String title;
+  private String content;
+  private Category category;
+  private Integer price;
+  private String desiredPlaceName;
+  private BigDecimal desiredPlaceLongitude;
+  private BigDecimal desiredPlaceLatitude;
+  private Integer view;
+  private Boolean sharing;
+  private String townName;
+
+  @JsonCreator
+  public PostSaveRequest(String title, String content, Category category, Integer price,
+      String desiredPlaceName, BigDecimal desiredPlaceLongitude, BigDecimal desiredPlaceLatitude,
+      Boolean sharing, String townName) {
+    this.title = title;
+    this.content = content;
+    this.category = category;
+    this.price = price;
+    this.desiredPlaceName = desiredPlaceName;
+    this.desiredPlaceLongitude = desiredPlaceLongitude;
+    this.desiredPlaceLatitude = desiredPlaceLatitude;
+    this.view = 0;
+    this.sharing = sharing;
+    this.townName = townName;
+  }
+
+  public static Post toPost(PostSaveRequest postSaveRequest, Member loginMember, Town town) {
+    return new Post(postSaveRequest.title, postSaveRequest.content, postSaveRequest.category,
+        postSaveRequest.price, postSaveRequest.desiredPlaceName,
+        postSaveRequest.getDesiredPlaceLongitude(), postSaveRequest.desiredPlaceLatitude,
+        postSaveRequest.view, postSaveRequest.sharing, loginMember, town, StatusType.SELLING);
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/dangdang/server/domain/post/dto/response/PostDetailResponse.java
@@ -1,0 +1,26 @@
+package com.dangdang.server.domain.post.dto.response;
+
+
+import com.dangdang.server.domain.member.domain.entity.Member;
+import com.dangdang.server.domain.post.domain.entity.Post;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PostDetailResponse {
+
+  PostResponse postResponse;
+  Member member;
+  List<String> imageUrls;
+
+  private PostDetailResponse(PostResponse postResponse, Member member, List<String> imageUrls) {
+    this.postResponse = postResponse;
+    this.member = member;
+    this.imageUrls = imageUrls;
+  }
+
+  public static PostDetailResponse from(Post post, List<String> imageUrls) {
+    return new PostDetailResponse(PostResponse.from(post), post.getMember(), imageUrls);
+  }
+
+}

--- a/src/main/java/com/dangdang/server/domain/post/dto/response/PostResponse.java
+++ b/src/main/java/com/dangdang/server/domain/post/dto/response/PostResponse.java
@@ -1,0 +1,51 @@
+package com.dangdang.server.domain.post.dto.response;
+
+
+import com.dangdang.server.domain.common.StatusType;
+import com.dangdang.server.domain.post.domain.Category;
+import com.dangdang.server.domain.post.domain.entity.Post;
+import java.math.BigDecimal;
+import lombok.Getter;
+
+@Getter
+public class PostResponse {
+
+  private Long id;
+  private String title;
+  private String content;
+  private Category category;
+  private Integer price;
+  private String desiredPlaceName;
+  private BigDecimal desiredPlaceLongitude;
+  private BigDecimal desiredPlaceLatitude;
+  private Integer view;
+  private Boolean sharing;
+  private String townName;
+  private StatusType statusType;
+
+  private PostResponse(Long id, String title, String content, Category category, Integer price,
+      String desiredPlaceName, BigDecimal desiredPlaceLongitude, BigDecimal desiredPlaceLatitude,
+      Integer view, Boolean sharing, String townName, StatusType statusType) {
+    this.id = id;
+    this.title = title;
+    this.content = content;
+    this.category = category;
+    this.price = price;
+    this.desiredPlaceName = desiredPlaceName;
+    this.desiredPlaceLongitude = desiredPlaceLongitude;
+    this.desiredPlaceLatitude = desiredPlaceLatitude;
+    this.view = view;
+    this.sharing = sharing;
+    this.townName = townName;
+    this.statusType = statusType;
+  }
+
+  public static PostResponse from(Post post) {
+    return new PostResponse(
+        post.getId(), post.getTitle(), post.getContent(), post.getCategory(),
+        post.getPrice(), post.getDesiredPlaceName(), post.getDesiredPlaceLongitude(),
+        post.getDesiredPlaceLatitude(), post.getView(), post.getSharing(),
+        post.getTownName(), post.getStatus());
+  }
+
+}

--- a/src/main/java/com/dangdang/server/domain/post/dto/response/PostSliceResponse.java
+++ b/src/main/java/com/dangdang/server/domain/post/dto/response/PostSliceResponse.java
@@ -12,9 +12,6 @@ public class PostSliceResponse {
   private String townName;
   private LocalDateTime createdAt;
 
-  private PostSliceResponse() {
-  }
-
   private PostSliceResponse(Long id, String title, String townName, LocalDateTime createdAt) {
     this.id = id;
     this.title = title;

--- a/src/main/java/com/dangdang/server/domain/post/dto/response/PostsSliceResponse.java
+++ b/src/main/java/com/dangdang/server/domain/post/dto/response/PostsSliceResponse.java
@@ -9,9 +9,6 @@ public class PostsSliceResponse {
   private List<PostSliceResponse> postSliceResponses;
   private boolean hasNext;
 
-  private PostsSliceResponse() {
-  }
-
   private PostsSliceResponse(List<PostSliceResponse> postSliceResponses, boolean hasNext) {
     this.postSliceResponses = postSliceResponses;
     this.hasNext = hasNext;

--- a/src/main/java/com/dangdang/server/domain/post/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/dangdang/server/domain/post/exception/CategoryNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dangdang.server.domain.post.exception;
+
+import com.dangdang.server.global.exception.BusinessException;
+import com.dangdang.server.global.exception.ExceptionCode;
+
+public class CategoryNotFoundException extends BusinessException {
+
+  public CategoryNotFoundException(ExceptionCode exceptionCode) {
+    super(exceptionCode);
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/post/exception/PostNotFoundException.java
+++ b/src/main/java/com/dangdang/server/domain/post/exception/PostNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dangdang.server.domain.post.exception;
+
+import com.dangdang.server.global.exception.BusinessException;
+import com.dangdang.server.global.exception.ExceptionCode;
+
+public class PostNotFoundException extends BusinessException {
+
+  public PostNotFoundException(ExceptionCode exceptionCode) {
+    super(exceptionCode);
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/postImage/application/PostImageService.java
+++ b/src/main/java/com/dangdang/server/domain/postImage/application/PostImageService.java
@@ -1,0 +1,32 @@
+package com.dangdang.server.domain.postImage.application;
+
+import com.dangdang.server.domain.post.domain.entity.Post;
+import com.dangdang.server.domain.postImage.domain.PostImageRepository;
+import com.dangdang.server.domain.postImage.domain.entity.PostImage;
+import com.dangdang.server.domain.postImage.dto.PostImageRequest;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostImageService {
+
+  private final PostImageRepository postImageRepository;
+
+  public PostImageService(PostImageRepository postImageRepository) {
+    this.postImageRepository = postImageRepository;
+  }
+
+  public void savePostImage(Post post, PostImageRequest postImageRequest) {
+    List<String> urls = postImageRequest.getUrl();
+    urls.stream().map(url -> PostImageRequest.toPostImage(post, url))
+        .forEach(postImageRepository::save);
+  }
+
+  public List<String> findPostImagesByPostId(Long postId) {
+    List<PostImage> postImages = postImageRepository.findPostImagesByPostId(postId);
+    return postImages.stream().map(PostImage::getUrl)
+        .collect(Collectors.toList());
+
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/postImage/domain/PostImageRepository.java
+++ b/src/main/java/com/dangdang/server/domain/postImage/domain/PostImageRepository.java
@@ -1,0 +1,12 @@
+package com.dangdang.server.domain.postImage.domain;
+
+import com.dangdang.server.domain.postImage.domain.entity.PostImage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+
+  List<PostImage> findPostImagesByPostId(@Param("postId") Long postId);
+
+}

--- a/src/main/java/com/dangdang/server/domain/postImage/domain/entity/PostImage.java
+++ b/src/main/java/com/dangdang/server/domain/postImage/domain/entity/PostImage.java
@@ -32,4 +32,8 @@ public class PostImage extends BaseEntity {
   protected PostImage() {
   }
 
+  public PostImage(Post post, String url) {
+    this.post = post;
+    this.url = url;
+  }
 }

--- a/src/main/java/com/dangdang/server/domain/postImage/dto/PostImageRequest.java
+++ b/src/main/java/com/dangdang/server/domain/postImage/dto/PostImageRequest.java
@@ -1,0 +1,22 @@
+package com.dangdang.server.domain.postImage.dto;
+
+import com.dangdang.server.domain.post.domain.entity.Post;
+import com.dangdang.server.domain.postImage.domain.entity.PostImage;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PostImageRequest {
+
+  private List<String> url;
+
+  @JsonCreator
+  public PostImageRequest(List<String> url) {
+    this.url = url;
+  }
+
+  public static PostImage toPostImage(Post post, String url) {
+    return new PostImage(post, url);
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/town/domain/TownRepository.java
+++ b/src/main/java/com/dangdang/server/domain/town/domain/TownRepository.java
@@ -2,7 +2,10 @@ package com.dangdang.server.domain.town.domain;
 
 import com.dangdang.server.domain.town.domain.entity.Town;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TownRepository extends JpaRepository<Town, Long> {
 
@@ -11,5 +14,8 @@ public interface TownRepository extends JpaRepository<Town, Long> {
     @description : 게시글 전체 조회 로직에서 조회 대상이 될 동 id를 가져오기 위해 임시로 작성한 메서드입니다.
     실제 동작하지 않으므로 편의에 맞게 수정해주세요. 인터페이스만 만들어둔 것입니다.
    */
-  public List<Long> findAdjacencyTownIdByRangeTypeAndTownId(long townId, int range);
+  @Query("select t from Town t")
+  List<Long> findAdjacencyTownId(@Param("townId") long townId, @Param(("range")) int range);
+
+  Optional<Town> findTownByName(@Param("name") String name);
 }

--- a/src/main/java/com/dangdang/server/domain/town/exception/TownNotFoundException.java
+++ b/src/main/java/com/dangdang/server/domain/town/exception/TownNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dangdang.server.domain.town.exception;
+
+import com.dangdang.server.global.exception.BusinessException;
+import com.dangdang.server.global.exception.ExceptionCode;
+
+public class TownNotFoundException extends BusinessException {
+
+  public TownNotFoundException(ExceptionCode exceptionCode) {
+    super(exceptionCode);
+  }
+}

--- a/src/main/java/com/dangdang/server/global/exception/ExceptionCode.java
+++ b/src/main/java/com/dangdang/server/global/exception/ExceptionCode.java
@@ -1,7 +1,11 @@
 package com.dangdang.server.global.exception;
 
+import org.springframework.http.HttpStatus;
+
 public enum ExceptionCode {
-  ;
+  CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 카테고리가 존재하지 않습니다."),
+  TOWN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 도시가 존재하지 않습니다."),
+  POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 게시글이 존재하지 않습니다.");
 
   int status;
   String message;

--- a/src/main/java/com/dangdang/server/global/exception/ExceptionCode.java
+++ b/src/main/java/com/dangdang/server/global/exception/ExceptionCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionCode {
   CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 카테고리가 존재하지 않습니다."),
   TOWN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 도시가 존재하지 않습니다."),
-  POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 게시글이 존재하지 않습니다.");
+  POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 게시글이 존재하지 않습니다."),
+  BINDING_WRONG(HttpStatus.BAD_REQUEST.value(), "요청하신 필드값의 유효성이 잘못되었습니다.");
 
   int status;
   String message;

--- a/src/main/java/com/dangdang/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dangdang/server/global/exception/GlobalExceptionHandler.java
@@ -3,12 +3,20 @@ package com.dangdang.server.global.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+  @ExceptionHandler(BindException.class)
+  protected ResponseEntity<String> handleBindException(BindException e) {
+    int httpStatus = ExceptionCode.BINDING_WRONG.getStatus();
+    String message = ExceptionCode.BINDING_WRONG.getMessage();
+    return ResponseEntity.status(httpStatus).body(message);
+  }
 
   @ExceptionHandler(BusinessException.class)
   protected ResponseEntity<String> handledException(BusinessException e) {

--- a/src/test/java/com/dangdang/server/domain/post/application/PostServiceTest.java
+++ b/src/test/java/com/dangdang/server/domain/post/application/PostServiceTest.java
@@ -1,0 +1,62 @@
+package com.dangdang.server.domain.post.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.dangdang.server.domain.member.domain.MemberRepository;
+import com.dangdang.server.domain.member.domain.entity.Member;
+import com.dangdang.server.domain.post.domain.Category;
+import com.dangdang.server.domain.post.dto.request.PostSaveRequest;
+import com.dangdang.server.domain.post.dto.response.PostResponse;
+import com.dangdang.server.domain.post.exception.PostNotFoundException;
+import com.dangdang.server.domain.town.domain.TownRepository;
+import com.dangdang.server.domain.town.domain.entity.Town;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class PostServiceTest {
+
+  @Autowired
+  PostService postService;
+  @Autowired
+  MemberRepository memberRepository;
+  @Autowired
+  TownRepository townRepository;
+
+  @Test
+  @DisplayName("게시글을 작성할 수 있다.")
+  void postSaveTest() {
+    Member loginMember = new Member("테스트 멤버", "01012341234", "testImgUrl");
+    memberRepository.save(loginMember);
+    Town town = new Town("서현동", null, null);
+    townRepository.save(town);
+
+    PostSaveRequest postSaveRequest = new PostSaveRequest(
+        "title1", "content1", Category.디지털기기, 1000,
+        "서현동 코지카페", BigDecimal.valueOf(123L), BigDecimal.valueOf(123L), false, "서현동");
+    PostResponse savedPostResponse = postService.savePost(postSaveRequest, loginMember);
+
+    PostResponse foundPostResponse = postService.findPostById(savedPostResponse.getId());
+    assertThat(savedPostResponse).usingRecursiveComparison().isEqualTo(foundPostResponse);
+  }
+
+  @Test
+  @DisplayName("게시글 조회시 해당하는 id값이 없다면 PostNotFoundException이 발생한다.")
+  void findPostByIdInCorrect() {
+    Long wrongId = 9999L;
+
+    assertThatThrownBy(() -> postService.findPostById(wrongId))
+        .isInstanceOf(PostNotFoundException.class);
+
+  }
+
+
+}

--- a/src/test/java/com/dangdang/server/domain/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/dangdang/server/domain/post/domain/PostRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.dangdang.server.domain.post.domain;
 
+import com.dangdang.server.domain.common.StatusType;
 import com.dangdang.server.domain.member.domain.MemberRepository;
 import com.dangdang.server.domain.member.domain.entity.Member;
 import com.dangdang.server.domain.post.domain.entity.Post;
@@ -9,6 +10,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -37,9 +39,9 @@ class PostRepositoryTest {
       Town town = new Town("테스트 동" + i, null, null);
       townRepository.save(town);
 
-      Post post = new Post("제목" + i, "내용" + i, Category.가전제품, 20000,
+      Post post = new Post("제목" + i, "내용" + i, Category.디지털기기, 20000,
           null, null, null, 0, false,
-          member, town);
+          member, town, StatusType.SELLING);
       // when
       postRepository.save(post);
     }
@@ -47,6 +49,7 @@ class PostRepositoryTest {
   }
 
   @Test
+  @DisplayName("게시글을 페이징 처리 할 수 있다.")
   public void getAllPosts() throws Exception {
     //given
     List<Post> posts = postRepository.findAll();


### PR DESCRIPTION
### 변경 내용 요약
판매자 정보, 게시글 이미지 url, 게시글 정보를 제공하는 게시글 상세페이지를 조회 기능을 구현하였습니다.

### 작업한 내용
- 게시글 상세 페이지 조회 구현

### 관련 링크
- [TRYC-50](https://cloudwi.atlassian.net/browse/TRYC-50)

### 기타 사항
- controller는 login기능이 merge된 후에 추가하겠습니다.
- dto부분에서 member 엔티티를 그대로 리턴하는데, 추후 member도메인이 merge된 후에 dto로 수정하겠습니다.
- dto는 추후에 record로 변경하겠습니다.

[TRYC-50]: https://cloudwi.atlassian.net/browse/TRYC-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ