### PR TITLE
[TRYC-144] 연결계좌 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/dangdang/server/controller/ConnectionAccountDatabaseController.java
+++ b/src/main/java/com/dangdang/server/controller/ConnectionAccountDatabaseController.java
@@ -3,9 +3,12 @@ package com.dangdang.server.controller;
 import com.dangdang.server.domain.member.domain.entity.Member;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.application.ConnectionAccountDatabaseService;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.AddConnectionAccountRequest;
+import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.GetAllConnectionAccountResponse;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +40,19 @@ public class ConnectionAccountDatabaseController {
         addConnectionAccountRequest);
 
     return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 내 연결 계좌 리스트 제공 API
+   */
+  @GetMapping("")
+  public ResponseEntity<List<GetAllConnectionAccountResponse>> getAllConnectionAccountResponse(
+      Authentication authentication) {
+    Long memberId = ((Member) authentication.getPrincipal()).getId();
+
+    List<GetAllConnectionAccountResponse> allConnectionAccount = connectionAccountDataBaseService.getAllConnectionAccount(
+        memberId);
+
+    return ResponseEntity.ok(allConnectionAccount);
   }
 }

--- a/src/main/java/com/dangdang/server/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/dangdang/server/domain/member/domain/entity/Member.java
@@ -21,7 +21,7 @@ public class Member extends BaseEntity {
   @Column(nullable = false, length = 30)
   private String nickname;
 
-  @Column(nullable = false, length = 30)
+  @Column(nullable = false, unique = true, length = 30)
   private String phoneNumber;
 
   @Column

--- a/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/application/ConnectionAccountDatabaseService.java
+++ b/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/application/ConnectionAccountDatabaseService.java
@@ -11,9 +11,11 @@ import com.dangdang.server.domain.pay.banks.bankAccount.exception.InactiveBankAc
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.ConnectionAccountRepository;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.entity.ConnectionAccount;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.AddConnectionAccountRequest;
+import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.GetAllConnectionAccountResponse;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.exception.EmptyResultException;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.domain.PayMemberRepository;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.domain.entity.PayMember;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,4 +54,20 @@ public class ConnectionAccountDatabaseService {
     ConnectionAccount connectionAccount = new ConnectionAccount(bankAccount, payMember);
     return connectionAccountRepository.save(connectionAccount);
   }
+
+  /**
+   * 내 연결 계좌 리스트 제공
+   */
+  public List<GetAllConnectionAccountResponse> getAllConnectionAccount(Long memberId) {
+    PayMember payMember = payMemberRepository.findByMemberId(memberId)
+        .orElseThrow(() -> new EmptyResultException(PAY_MEMBER_NOT_FOUND));
+
+    List<ConnectionAccount> connectionAccountList = connectionAccountRepository.findByPayMemberId(
+        payMember.getId());
+
+    return connectionAccountList.stream()
+        .map(GetAllConnectionAccountResponse::from)
+        .toList();
+  }
+
 }

--- a/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/domain/ConnectionAccountRepository.java
+++ b/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/domain/ConnectionAccountRepository.java
@@ -1,10 +1,12 @@
 package com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain;
 
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.entity.ConnectionAccount;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ConnectionAccountRepository extends JpaRepository<ConnectionAccount, Long> {
 
+  List<ConnectionAccount> findByPayMemberId(Long payMemberId);
 }

--- a/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/dto/GetAllConnectionAccountResponse.java
+++ b/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/dto/GetAllConnectionAccountResponse.java
@@ -1,0 +1,11 @@
+package com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto;
+
+import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.entity.ConnectionAccount;
+
+public record GetAllConnectionAccountResponse(String bankName, String connectionAccountNumber) {
+
+  public static GetAllConnectionAccountResponse from(ConnectionAccount connectionAccount) {
+    return new GetAllConnectionAccountResponse(connectionAccount.getBank(),
+        connectionAccount.getBankAccountNumber());
+  }
+}

--- a/src/test/java/com/dangdang/server/domain/pay/daangnpay/connectionAccount/application/ConnectionAccountDatabaseServiceTest.java
+++ b/src/test/java/com/dangdang/server/domain/pay/daangnpay/connectionAccount/application/ConnectionAccountDatabaseServiceTest.java
@@ -13,6 +13,7 @@ import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.applica
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.ConnectionAccountRepository;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.entity.ConnectionAccount;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.AddConnectionAccountRequest;
+import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.GetAllConnectionAccountResponse;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.domain.PayMemberRepository;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.domain.entity.PayMember;
 import java.util.List;
@@ -101,4 +102,62 @@ class ConnectionAccountDatabaseServiceTest {
               addConnectionAccountRequest));
     }
   }
+
+  @Nested
+  @DisplayName("연결계좌 리스트를 조회했을 때")
+  class getAllConnectionAccountTest {
+
+    int allBankAccountSize = 0;
+    List<BankAccount> allBankAccount;
+
+    @BeforeEach
+    void setUp() {
+      allBankAccount = bankAccountRepository.findAll();
+      allBankAccountSize = allBankAccount.size();
+    }
+
+    @Nested
+    @DisplayName("성공")
+    class Success {
+
+      @Nested
+      @DisplayName("고객의 당근페이 연결계좌가 존재할 경우")
+      class WhenExistConnectionAccount {
+
+        @Test
+        @DisplayName("전체 리스트가 조회된다.")
+        void getAllConnectionAccountList() {
+          for (BankAccount account : allBankAccount) {
+            ConnectionAccount connectionAccount = new ConnectionAccount(account, payMember);
+            connectionAccountRepository.save(connectionAccount);
+          }
+
+          Long memberId = member.getId();
+
+          List<GetAllConnectionAccountResponse> allConnectionAccount = connectionAccountDataBaseService.getAllConnectionAccount(
+              memberId);
+
+          assertThat(allConnectionAccount).hasSize(allBankAccountSize);
+        }
+      }
+
+
+      @Nested
+      @DisplayName("고객의 당근페이 연결계좌가 존재하지 않을 경우")
+      class WhenZeroConnectionAccount {
+
+        @Test
+        @DisplayName("빈 리스트가 조회된다.")
+        void getZeroList() {
+          Long memberId = member.getId();
+
+          List<GetAllConnectionAccountResponse> allConnectionAccount = connectionAccountDataBaseService.getAllConnectionAccount(
+              memberId);
+
+          assertThat(allConnectionAccount).isEmpty();
+        }
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
### 변경 내용 요약
당근페이 연결계좌 리스트 조회 API 구현

### 작업한 내용
- 고객의 당근페이 연결계좌 리스트 제공

### 관련 링크
- [지라 티켓](https://cloudwi.atlassian.net/jira/software/projects/TRYC/boards/1/roadmap?selectedIssue=TRYC-144) <!-- 괄호 안에 지라 티켓 링크 넣어주세요. -->

### 기타 사항
컨트롤러 테스트는 추후 추가할 예정이에요
dev 브랜치에 이전 작업(125)이 아직 머지가 되지 않아서 125 브랜치에서 이어서 추가작업을 했더니 커밋 내역이 중복으로 들어왔네요
마지막 커밋 내역 [4d58d40](https://github.com/BE-03-Dangdang/Dangdang-Server/pull/10/commits/4d58d4042837f1b0ac23c1a7b11e587223b4fa90)만 확인부탁드려요!
