### PR TITLE
[TRYC-151] 인접 동 MongoDB 저장 및 인접 동 id list 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // mongodb
+    implementation ('org.springframework.boot:spring-boot-starter-data-mongodb')
+
     // S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 

--- a/src/main/java/com/dangdang/server/domain/town/application/TownService.java
+++ b/src/main/java/com/dangdang/server/domain/town/application/TownService.java
@@ -1,0 +1,63 @@
+package com.dangdang.server.domain.town.application;
+
+import static com.dangdang.server.global.exception.ExceptionCode.TOWN_NOT_FOUND;
+
+import com.dangdang.server.domain.town.domain.AdjacentTownRepository;
+import com.dangdang.server.domain.town.domain.RangeRepository;
+import com.dangdang.server.domain.town.domain.TownRepository;
+import com.dangdang.server.domain.town.domain.entity.AdjacentTown;
+import com.dangdang.server.domain.town.domain.entity.Range;
+import com.dangdang.server.domain.town.domain.entity.Town;
+import com.dangdang.server.domain.town.dto.AdjacentTownResponse;
+import com.dangdang.server.domain.town.exception.TownNotFoundException;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class TownService {
+
+  private static final Map<String, Integer> rangeLevels = Map.of("1", 1, "2", 2, "3", 4, "4", 6);
+
+  private final TownRepository townRepository;
+  private final AdjacentTownRepository adjacentTownRepository;
+  private final RangeRepository rangeRepository;
+
+  public TownService(TownRepository townRepository, AdjacentTownRepository adjacentTownRepository,
+      RangeRepository rangeRepository) {
+    this.townRepository = townRepository;
+    this.adjacentTownRepository = adjacentTownRepository;
+    this.rangeRepository = rangeRepository;
+  }
+
+  public void analyzeAdjacentTowns() {
+    // 모든 town Id에 대해서 인접 document 생성
+    List<Town> towns = townRepository.findAll();
+    towns.forEach(town -> {
+      Range[] ranges = new Range[4];
+      for (String currLevel : rangeLevels.keySet()) {
+        int distance = rangeLevels.get(currLevel);
+        List<AdjacentTownResponse> adjacentTownResponses = townRepository.findAdjacentTownsByPoint(
+            town.getLatitude(), town.getLongitude(), distance);
+
+        List<Long> ids = adjacentTownResponses.stream().map(AdjacentTownResponse::getTownId)
+            .toList();
+        List<String> names = adjacentTownResponses.stream().map(AdjacentTownResponse::getName)
+            .toList();
+        Range save = rangeRepository.save(new Range(town.getName(), currLevel, ids, names));
+        int rangeIndex = Integer.parseInt(currLevel) - 1;
+        ranges[rangeIndex] = save;
+      }
+      AdjacentTown adjacentTown = new AdjacentTown(town.getName(), ranges);
+      adjacentTownRepository.save(adjacentTown);
+    });
+  }
+
+  public List<Long> findAdjacentTownWithRangeLevel(String name, String level) {
+    Range range = rangeRepository.findAdjacentTownIds(name, level)
+        .orElseThrow(() -> new TownNotFoundException(TOWN_NOT_FOUND));
+    return range.getIds();
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/town/domain/AdjacentTownRepository.java
+++ b/src/main/java/com/dangdang/server/domain/town/domain/AdjacentTownRepository.java
@@ -1,0 +1,8 @@
+package com.dangdang.server.domain.town.domain;
+
+import com.dangdang.server.domain.town.domain.entity.AdjacentTown;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface AdjacentTownRepository extends MongoRepository<AdjacentTown, String> {
+
+}

--- a/src/main/java/com/dangdang/server/domain/town/domain/RangeRepository.java
+++ b/src/main/java/com/dangdang/server/domain/town/domain/RangeRepository.java
@@ -1,0 +1,12 @@
+package com.dangdang.server.domain.town.domain;
+
+import com.dangdang.server.domain.town.domain.entity.Range;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+public interface RangeRepository extends MongoRepository<Range, String> {
+
+  @Query("{'$and':[ {'name' : ?0}, {'level': ?1} ] }")
+  Optional<Range> findAdjacentTownIds(String townName, String level);
+}

--- a/src/main/java/com/dangdang/server/domain/town/domain/entity/AdjacentTown.java
+++ b/src/main/java/com/dangdang/server/domain/town/domain/entity/AdjacentTown.java
@@ -1,0 +1,23 @@
+package com.dangdang.server.domain.town.domain.entity;
+
+
+import javax.persistence.Id;
+import lombok.Getter;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "adjacentTown")
+@Getter
+public class AdjacentTown {
+
+  @Id
+  private ObjectId id;
+  private String name;
+  private Range[] ranges;
+
+
+  public AdjacentTown(String name, Range[] ranges) {
+    this.name = name;
+    this.ranges = ranges;
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/town/domain/entity/Range.java
+++ b/src/main/java/com/dangdang/server/domain/town/domain/entity/Range.java
@@ -1,0 +1,28 @@
+package com.dangdang.server.domain.town.domain.entity;
+
+import java.util.List;
+import javax.persistence.Id;
+import lombok.Getter;
+import lombok.ToString;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document("range")
+@ToString
+@Getter
+public class Range {
+
+  @Id
+  private ObjectId id;
+  private String name;
+  private String level;
+  private List<Long> ids;
+  private List<String> names;
+
+  public Range(String name, String level, List<Long> ids, List<String> names) {
+    this.name = name;
+    this.level = level;
+    this.ids = ids;
+    this.names = names;
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/town/domain/entity/Town.java
+++ b/src/main/java/com/dangdang/server/domain/town/domain/entity/Town.java
@@ -25,10 +25,10 @@ public class Town extends BaseEntity {
   private String name;
 
   @Column(precision = 18, scale = 10)
-  private BigDecimal longitude;
+  private BigDecimal latitude;
 
   @Column(precision = 18, scale = 10)
-  private BigDecimal latitude;
+  private BigDecimal longitude;
 
   @OneToMany(mappedBy = "town")
   private List<MemberTown> memberTownList;
@@ -36,9 +36,9 @@ public class Town extends BaseEntity {
   protected Town() {
   }
 
-  public Town(String name, BigDecimal longitude, BigDecimal latitude) {
+  public Town(String name, BigDecimal latitude, BigDecimal longitude) {
     this.name = name;
-    this.longitude = longitude;
     this.latitude = latitude;
+    this.longitude = longitude;
   }
 }

--- a/src/main/java/com/dangdang/server/domain/town/dto/AdjacentTownResponse.java
+++ b/src/main/java/com/dangdang/server/domain/town/dto/AdjacentTownResponse.java
@@ -1,0 +1,10 @@
+package com.dangdang.server.domain.town.dto;
+
+public interface AdjacentTownResponse {
+
+  long getTownId();
+
+  String getName();
+
+  Double getDistance();
+}

--- a/src/test/java/com/dangdang/server/domain/town/application/TownServiceTest.java
+++ b/src/test/java/com/dangdang/server/domain/town/application/TownServiceTest.java
@@ -1,0 +1,59 @@
+package com.dangdang.server.domain.town.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dangdang.server.domain.town.domain.AdjacentTownRepository;
+import com.dangdang.server.domain.town.domain.TownRepository;
+import com.dangdang.server.domain.town.domain.entity.AdjacentTown;
+import com.dangdang.server.domain.town.domain.entity.Town;
+import com.dangdang.server.domain.town.dto.AdjacentTownResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class TownServiceTest {
+
+  @Autowired
+  private TownService townService;
+  @Autowired
+  private TownRepository townRepository;
+  @Autowired
+  private AdjacentTownRepository adjacentTownRepository;
+
+  @Test
+  @DisplayName("Town 테이블에서 거리 레벨에 따른 인접 동들을 mongoDB로 저장할 수 있다.")
+  public void makeAdjacentTowns() throws Exception {
+    //given
+    townService.analyzeAdjacentTowns();
+    List<Town> towns = townRepository.findAll();
+    // when
+    List<AdjacentTown> adjacentTowns = adjacentTownRepository.findAll();
+    //then
+    assertThat(adjacentTowns).hasSize(towns.size());
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {"1:1", "2:2", "3:4", "4:6"}, delimiter = ':')
+  @DisplayName("Town 이름과 Range level로 인접 지역 id 리스트를 조회할 수 있다.")
+  public void findAdjacentTownWithRangeLevel(String level, int distance) throws Exception {
+    //given
+    String townName = "천호동";
+    // when
+    List<Long> ids = townService.findAdjacentTownWithRangeLevel(townName, level);
+    Town town = townRepository.findByName(townName).orElseThrow();
+
+    List<AdjacentTownResponse> adjacentTowns = townRepository.findAdjacentTownsByPoint(
+        town.getLatitude(), town.getLongitude(), distance);
+
+    //then
+    List<Long> townIdsFromTable = adjacentTowns.stream().map(AdjacentTownResponse::getTownId)
+        .toList();
+    assertThat(ids).hasSize(adjacentTowns.size());
+    assertThat(ids).usingRecursiveComparison().isEqualTo(townIdsFromTable);
+  }
+}


### PR DESCRIPTION
### 변경 내용 요약
- MongoDB 의존성 추가 (build.gradle)
- TownRepository, TownService : 인접 동 MongoDB 저장 및 조회 기능 구현
- 이 기능은 다른 컨트롤러에서 호출해서 사용할 목적으로 만들었기 때문에 따로 TownController를 작성하지 않음

### 작업한 내용
- 인접 동 조회에서 mongodb 사용을 위해 의존성 추가했습니다.
- 인접 동 정보를 mongoDB에 insert하는 로직을 추가했습니다.
- Query는 TownRepository에 있으며 방법은 2가지 모두 넣어놨습니다.
  - 이름은 findAdjacentTownsByPoint, findTowns 입니다.
- 동 이름과 탐색 레벨을 입력했을 때 이에 맞춰서 동 id 목록을 반환하는 로직을 작성했습니다.
- 이에 따른 테스트 코드를 작성했습니다.

### 관련 링크
- [TRYC-151](https://cloudwi.atlassian.net/browse/TRYC-151)

### 기타 사항
- 머지되면 mongodb 관련 application.yml 추가해 놓겠습니다.


[TRYC-151]: https://cloudwi.atlassian.net/browse/TRYC-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ