### PR TITLE
[TRYC-159] pay domain controller refactoring

### DIFF
--- a/src/main/java/com/dangdang/server/controller/pay/ConnectionAccountDatabaseController.java
+++ b/src/main/java/com/dangdang/server/controller/pay/ConnectionAccountDatabaseController.java
@@ -3,15 +3,17 @@ package com.dangdang.server.controller.pay;
 import com.dangdang.server.domain.member.domain.entity.Member;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.application.ConnectionAccountDatabaseService;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.AddConnectionAccountRequest;
+import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.AllConnectionAccount;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.GetAllConnectionAccountResponse;
 import java.util.List;
+import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -31,28 +33,26 @@ public class ConnectionAccountDatabaseController {
   /**
    * 연결계좌 추가 API
    */
+  @ResponseStatus(HttpStatus.OK)
   @PostMapping("")
-  public ResponseEntity<HttpStatus> addConnectionAccount(Authentication authentication,
-      @RequestBody AddConnectionAccountRequest addConnectionAccountRequest) {
+  public void addConnectionAccount(Authentication authentication,
+      @RequestBody @Valid AddConnectionAccountRequest addConnectionAccountRequest) {
     Long memberId = ((Member) authentication.getPrincipal()).getId();
 
     connectionAccountDataBaseService.addConnectionAccount(memberId,
         addConnectionAccountRequest);
-
-    return ResponseEntity.ok().build();
   }
 
   /**
    * 내 연결 계좌 리스트 제공 API
    */
   @GetMapping("")
-  public ResponseEntity<List<GetAllConnectionAccountResponse>> getAllConnectionAccountResponse(
+  public GetAllConnectionAccountResponse getAllConnectionAccountResponse(
       Authentication authentication) {
     Long memberId = ((Member) authentication.getPrincipal()).getId();
 
-    List<GetAllConnectionAccountResponse> allConnectionAccount = connectionAccountDataBaseService.getAllConnectionAccount(
+    List<AllConnectionAccount> allConnectionAccount = connectionAccountDataBaseService.getAllConnectionAccount(
         memberId);
-
-    return ResponseEntity.ok(allConnectionAccount);
+    return GetAllConnectionAccountResponse.from(allConnectionAccount);
   }
 }

--- a/src/main/java/com/dangdang/server/controller/pay/PayMemberController.java
+++ b/src/main/java/com/dangdang/server/controller/pay/PayMemberController.java
@@ -8,7 +8,6 @@ import com.dangdang.server.domain.pay.daangnpay.domain.payMember.dto.ReceiveRequ
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.dto.ReceiveResponse;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,25 +30,23 @@ public class PayMemberController {
   /**
    * 당근머니 충전 API
    */
+  @ResponseStatus(HttpStatus.OK)
   @PatchMapping("/money/charge")
-  public ResponseEntity<PayResponse> charge(Authentication authentication,
+  public PayResponse charge(Authentication authentication,
       @RequestBody @Valid PayRequest payRequest) {
     Long memberId = ((Member) authentication.getPrincipal()).getId();
-    PayResponse payResponse = payMemberService.charge(memberId, payRequest);
-
-    return ResponseEntity.ok(payResponse);
+    return payMemberService.charge(memberId, payRequest);
   }
 
   /**
    * 당근머니 출금 API
    */
+  @ResponseStatus(HttpStatus.OK)
   @PatchMapping("/money/withdraw")
-  public ResponseEntity<PayResponse> withdraw(Authentication authentication,
+  public PayResponse withdraw(Authentication authentication,
       @RequestBody @Valid PayRequest payRequest) {
     Long memberId = ((Member) authentication.getPrincipal()).getId();
-    PayResponse payResponse = payMemberService.withdraw(memberId, payRequest);
-
-    return ResponseEntity.ok(payResponse);
+    return payMemberService.withdraw(memberId, payRequest);
   }
 
   /**

--- a/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/application/ConnectionAccountDatabaseService.java
+++ b/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/application/ConnectionAccountDatabaseService.java
@@ -11,7 +11,7 @@ import com.dangdang.server.domain.pay.banks.bankAccount.exception.InactiveBankAc
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.ConnectionAccountRepository;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.entity.ConnectionAccount;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.AddConnectionAccountRequest;
-import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.GetAllConnectionAccountResponse;
+import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.AllConnectionAccount;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.GetConnectionAccountReceiveResponse;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.exception.EmptyResultException;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.domain.PayMemberRepository;
@@ -59,14 +59,14 @@ public class ConnectionAccountDatabaseService {
   /**
    * 내 연결 계좌 리스트 제공
    */
-  public List<GetAllConnectionAccountResponse> getAllConnectionAccount(Long memberId) {
+  public List<AllConnectionAccount> getAllConnectionAccount(Long memberId) {
     PayMember payMember = getPayMemberByMemberId(memberId);
 
     List<ConnectionAccount> connectionAccountList = connectionAccountRepository.findByPayMemberId(
         payMember.getId());
 
     return connectionAccountList.stream()
-        .map(GetAllConnectionAccountResponse::from)
+        .map(AllConnectionAccount::from)
         .toList();
   }
 

--- a/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/dto/AllConnectionAccount.java
+++ b/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/dto/AllConnectionAccount.java
@@ -1,0 +1,11 @@
+package com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto;
+
+import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.entity.ConnectionAccount;
+
+public record AllConnectionAccount(String bankName, String connectionAccountNumber) {
+
+  public static AllConnectionAccount from(ConnectionAccount connectionAccount) {
+    return new AllConnectionAccount(connectionAccount.getBank(),
+        connectionAccount.getBankAccountNumber());
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/dto/GetAllConnectionAccountResponse.java
+++ b/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/dto/GetAllConnectionAccountResponse.java
@@ -1,11 +1,11 @@
 package com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto;
 
-import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.entity.ConnectionAccount;
+import java.util.List;
 
-public record GetAllConnectionAccountResponse(String bankName, String connectionAccountNumber) {
+public record GetAllConnectionAccountResponse(List<AllConnectionAccount> allConnectionAccounts) {
 
-  public static GetAllConnectionAccountResponse from(ConnectionAccount connectionAccount) {
-    return new GetAllConnectionAccountResponse(connectionAccount.getBank(),
-        connectionAccount.getBankAccountNumber());
+  public static GetAllConnectionAccountResponse from(
+      List<AllConnectionAccount> allConnectionAccounts) {
+    return new GetAllConnectionAccountResponse(allConnectionAccounts);
   }
 }

--- a/src/test/java/com/dangdang/server/domain/pay/daangnpay/connectionAccount/ConnectionAccountDatabaseServiceTest.java
+++ b/src/test/java/com/dangdang/server/domain/pay/daangnpay/connectionAccount/ConnectionAccountDatabaseServiceTest.java
@@ -13,7 +13,7 @@ import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.applica
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.ConnectionAccountRepository;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.domain.entity.ConnectionAccount;
 import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.AddConnectionAccountRequest;
-import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.GetAllConnectionAccountResponse;
+import com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto.AllConnectionAccount;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.domain.PayMemberRepository;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.domain.entity.PayMember;
 import java.util.List;
@@ -134,7 +134,7 @@ class ConnectionAccountDatabaseServiceTest {
 
           Long memberId = member.getId();
 
-          List<GetAllConnectionAccountResponse> allConnectionAccount = connectionAccountDataBaseService.getAllConnectionAccount(
+          List<AllConnectionAccount> allConnectionAccount = connectionAccountDataBaseService.getAllConnectionAccount(
               memberId);
 
           assertThat(allConnectionAccount).hasSize(allBankAccountSize);
@@ -150,7 +150,7 @@ class ConnectionAccountDatabaseServiceTest {
         void getZeroList() {
           Long memberId = member.getId();
 
-          List<GetAllConnectionAccountResponse> allConnectionAccount = connectionAccountDataBaseService.getAllConnectionAccount(
+          List<AllConnectionAccount> allConnectionAccount = connectionAccountDataBaseService.getAllConnectionAccount(
               memberId);
 
           assertThat(allConnectionAccount).isEmpty();


### PR DESCRIPTION
### 변경 내용 요약
- 당근페이 도메인 컨트롤러 리팩토링

### 작업한 내용
- ResponseEntity → @ResponseStatus 변경
  - 별도의 커스텀 응답값이 없는 상황이므로 응답 방식을 변경하여 불필요한 코드를 줄이고 코드 가독성을 향상시킴
- 연결계좌 조회 API list DTO 생성
- controller 실패 테스트 코드 추가

### 관련 링크
- [지라 티켓](https://cloudwi.atlassian.net/jira/software/projects/TRYC/boards/1/backlog?selectedIssue=TRYC-159) <!-- 괄호 안에 지라 티켓 링크 넣어주세요. -->
