### PR TITLE
[TRYC-169] 수취 조회 API 외부 연동 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ out/
 .vscode/
 
 application*.yml
+application*.properties
 .DS_Store

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -7,19 +7,12 @@ backtony.github.io(Rest Docs)
 :toclevels: 2
 :sectlinks:
 
-[[PayExternal-API]]
-== PayExternal API
-
-[[PayExternal-당근머니-충전]]
-=== PayExternal 당근머니 충전
-
-operation::PayExternalController/charge[snippets='http-request,request-headers,http-response,response-fields']
-
 [[PayMember-API]]
 == PayMember API
 
 [[PayMember-당근페이-가입]]
 === PayMember 당근페이 가입
+
 operation::PayMemberController/signup[snippets='http-request,request-headers,http-response,response-fields']
 
 [[PayMember-당근머니-충전]]

--- a/src/main/java/com/dangdang/server/controller/pay/PayExternalController.java
+++ b/src/main/java/com/dangdang/server/controller/pay/PayExternalController.java
@@ -1,13 +1,10 @@
 package com.dangdang.server.controller.pay;
 
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.application.PayMemberService;
-import com.dangdang.server.domain.pay.daangnpay.domain.payMember.dto.PayRequest;
-import com.dangdang.server.domain.pay.daangnpay.domain.payMember.dto.PayResponse;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.dto.PostPayMemberRequest;
 import com.dangdang.server.domain.pay.kftc.feignClient.dto.GetAuthTokenRequest;
 import com.dangdang.server.domain.pay.kftc.feignClient.dto.GetAuthTokenResponse;
 import com.dangdang.server.domain.pay.kftc.feignClient.dto.GetUserMeResponse;
-import com.dangdang.server.global.aop.CurrentUserId;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -63,16 +60,4 @@ public class PayExternalController {
       @RequestHeader(value = "Authorization") String token, @RequestParam String userSeqNo) {
     return payMemberService.getUserMeResponse(token, userSeqNo);
   }
-
-  /**
-   * 당근머니 충전
-   */
-  @CurrentUserId
-  @ResponseStatus(HttpStatus.OK)
-  @PostMapping("/transfer/withdraw/fin_num")
-  public PayResponse charge(Long memberId, @RequestBody PayRequest payRequest) {
-    return payMemberService.charge(memberId, payRequest);
-  }
-
-
 }

--- a/src/main/java/com/dangdang/server/controller/pay/PayMemberController.java
+++ b/src/main/java/com/dangdang/server/controller/pay/PayMemberController.java
@@ -2,7 +2,6 @@ package com.dangdang.server.controller.pay;
 
 import static com.dangdang.server.global.exception.ExceptionCode.BINDING_WRONG;
 
-import com.dangdang.server.domain.member.domain.entity.Member;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.application.PayMemberService;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.dto.PayRequest;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.dto.PayResponse;
@@ -13,8 +12,6 @@ import com.dangdang.server.domain.pay.daangnpay.domain.payMember.exception.Passw
 import com.dangdang.server.global.aop.CurrentUserId;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,15 +32,15 @@ public class PayMemberController {
   /**
    * 당근페이 가입 API
    */
+  @CurrentUserId
   @ResponseStatus(HttpStatus.OK)
   @PostMapping("")
   public PostPayMemberSignupResponse createPayMember(@RequestParam String password,
-      Authentication authentication) {
+      Long memberId) {
     if (password.length() < 6) {
       throw new PasswordSizeException(BINDING_WRONG);
     }
-    Member member = (Member) authentication.getPrincipal();
-    return payMemberService.signup(password, member);
+    return payMemberService.signup(password, memberId);
   }
 
   /**
@@ -51,7 +48,7 @@ public class PayMemberController {
    */
   @CurrentUserId
   @ResponseStatus(HttpStatus.OK)
-  @PatchMapping("/money/charge")
+  @PostMapping("/money/charge")
   public PayResponse charge(Long memberId, @RequestBody @Valid PayRequest payRequest) {
     return payMemberService.charge(memberId, payRequest);
   }
@@ -61,7 +58,7 @@ public class PayMemberController {
    */
   @CurrentUserId
   @ResponseStatus(HttpStatus.OK)
-  @PatchMapping("/money/withdraw")
+  @PostMapping("/money/withdraw")
   public PayResponse withdraw(Long memberId, @RequestBody @Valid PayRequest payRequest) {
     return payMemberService.withdraw(memberId, payRequest);
   }

--- a/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/application/ConnectionAccountDatabaseService.java
+++ b/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/application/ConnectionAccountDatabaseService.java
@@ -83,17 +83,15 @@ public class ConnectionAccountDatabaseService {
         .filter(connectionAccount -> connectionAccount.getStatus().equals(StatusType.ACTIVE))
         .findFirst().orElseThrow();
 
-    return new GetConnectionAccountReceiveResponse(isMyAccount, findChargeAccount.getBank(),
+    return new GetConnectionAccountReceiveResponse(isMyAccount,
+        findChargeAccount.getAccountHolder(), findChargeAccount.getBank(),
         findChargeAccount.getBankAccountNumber());
   }
 
-  /**
-   * 핀테크 이용 번호 찾기
-   */
-  public String getFintechUseNum(String accountNumber) {
+  public ConnectionAccount findByAccountNumber(String accountNumber) {
     ConnectionAccount connectionAccount = connectionAccountRepository.findByBankAccountNumber(
         accountNumber).orElseThrow(() -> new EmptyResultException(BANK_ACCOUNT_NOT_FOUND));
-    return connectionAccount.getFintechUseNum();
+    return connectionAccount;
   }
 
   private PayMember getPayMemberByMemberId(Long memberId) {

--- a/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/domain/entity/ConnectionAccount.java
+++ b/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/domain/entity/ConnectionAccount.java
@@ -31,6 +31,9 @@ public class ConnectionAccount extends BaseEntity {
   @Column
   private String fintechUseNum;   // 오픈API를 통해 계좌등록을 하면 핀테크 이용번호가 부여된다.
 
+  @Column
+  private String accountHolder;
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "pay_member_id")
   private PayMember payMember;

--- a/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/dto/GetConnectionAccountReceiveResponse.java
+++ b/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/connectionAccount/dto/GetConnectionAccountReceiveResponse.java
@@ -2,6 +2,7 @@ package com.dangdang.server.domain.pay.daangnpay.domain.connectionAccount.dto;
 
 public record GetConnectionAccountReceiveResponse(
     boolean isMyAccount,
+    String accountHolder,
     String chargeAccountBankName,
     String chargeAccountNumber
 ) {

--- a/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/payMember/domain/entity/PayMember.java
+++ b/src/main/java/com/dangdang/server/domain/pay/daangnpay/domain/payMember/domain/entity/PayMember.java
@@ -1,16 +1,12 @@
 package com.dangdang.server.domain.pay.daangnpay.domain.payMember.domain.entity;
 
 import com.dangdang.server.domain.common.BaseEntity;
-import com.dangdang.server.domain.member.domain.entity.Member;
 import com.dangdang.server.domain.pay.daangnpay.domain.payMember.domain.FeeInfo;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
 import lombok.Getter;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -36,22 +32,21 @@ public class PayMember extends BaseEntity {
   @ColumnDefault("5")
   private Integer freeMonthlyFeeCount = 5;
 
-  @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id")
-  private Member member;
+  @Column(name = "member_id")
+  private Long memberId;
 
   protected PayMember() {
   }
 
-  public PayMember(String password, Member member) {
+  public PayMember(String password, Long memberId) {
     this.password = password;
-    this.member = member;
+    this.memberId = memberId;
   }
 
-  public PayMember(String password, Integer money, Member member) {
+  public PayMember(String password, Integer money, Long memberId) {
     this.password = password;
     this.money = money;
-    this.member = member;
+    this.memberId = memberId;
   }
 
   public PayMember(Integer money, Integer freeMonthlyFeeCount) {

--- a/src/main/java/com/dangdang/server/domain/pay/daangnpay/global/vo/TrustAccount.java
+++ b/src/main/java/com/dangdang/server/domain/pay/daangnpay/global/vo/TrustAccount.java
@@ -2,7 +2,7 @@ package com.dangdang.server.domain.pay.daangnpay.global.vo;
 
 public enum TrustAccount {
 
-  OPEN_BANKING_CONTRACT_ACCOUNT(1L, "1983471982748", "신한은행");
+  OPEN_BANKING_CONTRACT_ACCOUNT(1L, "200000000001", "신한은행");
 
   private final Long accountId;
   private final String accountNumber;

--- a/src/main/java/com/dangdang/server/domain/pay/kftc/common/dto/OpenBankingInquiryReceiveRequest.java
+++ b/src/main/java/com/dangdang/server/domain/pay/kftc/common/dto/OpenBankingInquiryReceiveRequest.java
@@ -1,6 +1,8 @@
 package com.dangdang.server.domain.pay.kftc.common.dto;
 
 public record OpenBankingInquiryReceiveRequest(Long payMemberId, String openBankingToken,
-                                               String bankAccountNumber, String bankCode) {
+                                               String bankName, String accountHolder,
+                                               String bankAccountNumber, String bankCode,
+                                               Integer depositAmount) {
 
 }

--- a/src/main/java/com/dangdang/server/domain/pay/kftc/common/dto/OpenBankingInquiryReceiveResponse.java
+++ b/src/main/java/com/dangdang/server/domain/pay/kftc/common/dto/OpenBankingInquiryReceiveResponse.java
@@ -1,7 +1,6 @@
 package com.dangdang.server.domain.pay.kftc.common.dto;
 
-import com.dangdang.server.domain.pay.banks.bankAccount.dto.BankOpenBankingApiResponse;
-import com.dangdang.server.domain.pay.kftc.openBankingFacade.domain.BankType;
+import com.dangdang.server.domain.pay.kftc.feignClient.dto.PostReceiveResponse;
 import java.time.LocalDateTime;
 
 public record OpenBankingInquiryReceiveResponse(Long payMemberId, String bankCode, String bankName,
@@ -10,12 +9,12 @@ public record OpenBankingInquiryReceiveResponse(Long payMemberId, String bankCod
                                                 LocalDateTime createdAt) {
 
   public static OpenBankingInquiryReceiveResponse of(Long payMemberId,
-      BankOpenBankingApiResponse bankOpenBankingApiResponse, LocalDateTime createdAt) {
-    BankType bankType = BankType.from(bankOpenBankingApiResponse.bankName());
+      PostReceiveResponse postReceiveResponse,
+      OpenBankingInquiryReceiveRequest openBankingInquiryReceiveRequest, LocalDateTime createdAt) {
 
-    return new OpenBankingInquiryReceiveResponse(payMemberId, bankType.getBankCode(),
-        bankType.getBankName(),
-        bankOpenBankingApiResponse.clientName(), bankOpenBankingApiResponse.accountNumber(),
-        createdAt);
+    return new OpenBankingInquiryReceiveResponse(payMemberId,
+        postReceiveResponse.bank_code_std(), openBankingInquiryReceiveRequest.bankName(),
+        postReceiveResponse.account_holder_name(),
+        openBankingInquiryReceiveRequest.bankAccountNumber(), createdAt);
   }
 }

--- a/src/main/java/com/dangdang/server/domain/pay/kftc/common/dto/OpenBankingWithdrawRequest.java
+++ b/src/main/java/com/dangdang/server/domain/pay/kftc/common/dto/OpenBankingWithdrawRequest.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.Min;
 
 public record OpenBankingWithdrawRequest(Long payMemberId, String openBankingToken,
                                          String fintechUseNum, String toTrustAccountNumber,
-                                         String fromBankAccountNumber, @Min(1) Integer amount) {
+                                         String accountHolder, String fromBankAccountNumber,
+                                         @Min(1) Integer amount) {
 
 }

--- a/src/main/java/com/dangdang/server/domain/pay/kftc/feignClient/OpenApiFeignClient.java
+++ b/src/main/java/com/dangdang/server/domain/pay/kftc/feignClient/OpenApiFeignClient.java
@@ -2,6 +2,8 @@ package com.dangdang.server.domain.pay.kftc.feignClient;
 
 import com.dangdang.server.domain.pay.kftc.feignClient.dto.GetAuthTokenResponse;
 import com.dangdang.server.domain.pay.kftc.feignClient.dto.GetUserMeResponse;
+import com.dangdang.server.domain.pay.kftc.feignClient.dto.PostReceiveReqeust;
+import com.dangdang.server.domain.pay.kftc.feignClient.dto.PostReceiveResponse;
 import com.dangdang.server.domain.pay.kftc.feignClient.dto.PostWithdrawRequest;
 import com.dangdang.server.domain.pay.kftc.feignClient.dto.PostWithdrawResponse;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -39,4 +41,11 @@ public interface OpenApiFeignClient {
   @PostMapping(value = "/v2.0/transfer/withdraw/fin_num", produces = "application/json")
   PostWithdrawResponse withdraw(@RequestHeader("Authorization") String token, @RequestBody
   PostWithdrawRequest postWithdrawRequest);
+
+  /**
+   * 수취 조회
+   */
+  @PostMapping(value = "/v2.0/inquiry/receive", produces = "application/json")
+  PostReceiveResponse inquiryReceive(@RequestHeader("Authorization") String openBankingToken,
+      @RequestBody PostReceiveReqeust postReceiveReqeust);
 }

--- a/src/main/java/com/dangdang/server/domain/pay/kftc/feignClient/dto/PostReceiveReqeust.java
+++ b/src/main/java/com/dangdang/server/domain/pay/kftc/feignClient/dto/PostReceiveReqeust.java
@@ -1,0 +1,39 @@
+package com.dangdang.server.domain.pay.kftc.feignClient.dto;
+
+import com.dangdang.server.domain.pay.kftc.common.dto.OpenBankingInquiryReceiveRequest;
+import lombok.Getter;
+
+@Getter
+public class PostReceiveReqeust extends RequestDtoHelper {
+
+  private String bank_tran_id;
+  private String cntr_account_type;
+  private String cntr_account_num;        // 신탁계좌
+  private String bank_code_std;
+  private String account_num;       // 수취 확인 입금 계좌
+  private String account_seq;
+  private String print_content;
+  private String tran_amt;      // 입금 요청 금액
+  private String req_client_name;
+  private String req_client_bank_code;
+  private String req_client_account_num;
+  private String req_client_num;
+  private String transfer_purpose;
+
+  public PostReceiveReqeust(String cntr_account_num,
+      OpenBankingInquiryReceiveRequest openBankingInquiryReceiveRequest) {
+    this.bank_tran_id = "M202300123U" + makeBankTranId();
+    this.cntr_account_type = "N";
+    this.transfer_purpose = "TR";
+    this.cntr_account_num = cntr_account_num;
+    this.bank_code_std = openBankingInquiryReceiveRequest.bankCode();
+    this.account_num = openBankingInquiryReceiveRequest.bankAccountNumber();
+    this.account_seq = String.valueOf((int) (Math.random() * 1000));
+    this.print_content = "당당페이";
+    this.tran_amt = openBankingInquiryReceiveRequest.depositAmount().toString();
+    this.req_client_name = openBankingInquiryReceiveRequest.accountHolder();
+    this.req_client_bank_code = openBankingInquiryReceiveRequest.bankCode();
+    this.req_client_account_num = openBankingInquiryReceiveRequest.bankAccountNumber();
+    this.req_client_num = makeBankTranId();
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/pay/kftc/feignClient/dto/PostReceiveResponse.java
+++ b/src/main/java/com/dangdang/server/domain/pay/kftc/feignClient/dto/PostReceiveResponse.java
@@ -1,0 +1,28 @@
+package com.dangdang.server.domain.pay.kftc.feignClient.dto;
+
+public record PostReceiveResponse(
+    String api_tran_id,
+    String api_tran_dtm,
+    String rsp_code,
+    String rsp_message,
+    String bank_code_std,
+    String bank_code_sub,
+    String bank_name,
+    String account_num,
+    String account_num_masked,
+    String print_content,
+    String account_holder_name,
+    String bank_tran_id,
+    String bank_tran_date,
+    String bank_code_tran,
+    String bank_rsp_code,
+    String bank_rsp_message,
+    String wd_bank_code_std,
+    String wd_bank_name,
+    String wd_account_num,
+    String tran_amt,
+    String cms_num,
+    String savings_bank_name,
+    String account_seq) {
+
+}

--- a/src/main/java/com/dangdang/server/domain/pay/kftc/feignClient/dto/PostWithdrawRequest.java
+++ b/src/main/java/com/dangdang/server/domain/pay/kftc/feignClient/dto/PostWithdrawRequest.java
@@ -1,14 +1,15 @@
 package com.dangdang.server.domain.pay.kftc.feignClient.dto;
 
+import com.dangdang.server.domain.pay.kftc.common.dto.OpenBankingWithdrawRequest;
 import lombok.Getter;
 
 @Getter
-public class PostWithdrawRequest extends BankTranIdMaker {
+public class PostWithdrawRequest extends RequestDtoHelper {
 
   private String cntr_account_type;
   private String transfer_purpose;
   private String bank_tran_id;  // 이용기관 코드(M202300123) + U + 난수 9자리(4B332018Z)
-  private String cntr_account_num;    // 입금 약정 계좌 번호
+  private String cntr_account_num;    // 약정 계좌 번호 (출금이체할 계좌)
   private String dps_print_content;
   private String fintech_use_num;   // 출금 계좌 핀테크 이용번호
   private String req_client_fintech_use_num;
@@ -23,23 +24,20 @@ public class PostWithdrawRequest extends BankTranIdMaker {
   protected PostWithdrawRequest() {
   }
 
-  public PostWithdrawRequest(String cntr_account_num, String dps_print_content,
-      String fintech_use_num, String req_client_fintech_use_num, String tran_amt, String tran_dtime,
-      String req_client_name, String req_client_num, String recv_client_name,
-      String recv_client_bank_code, String recv_client_account_num) {
+  public PostWithdrawRequest(OpenBankingWithdrawRequest openBankingWithdrawRequest) {
+    this.bank_tran_id = "M202300123U" + makeBankTranId();
     this.cntr_account_type = "N";
     this.transfer_purpose = "TR";
-    this.bank_tran_id = "M202300123U" + makeBankTranId();
-    this.cntr_account_num = cntr_account_num;
-    this.dps_print_content = dps_print_content;
-    this.fintech_use_num = fintech_use_num;
-    this.req_client_fintech_use_num = req_client_fintech_use_num;
-    this.tran_amt = tran_amt;
-    this.tran_dtime = tran_dtime;
-    this.req_client_name = req_client_name;
-    this.req_client_num = req_client_num;
-    this.recv_client_name = recv_client_name;
-    this.recv_client_bank_code = recv_client_bank_code;
-    this.recv_client_account_num = recv_client_account_num;
+    this.cntr_account_num = openBankingWithdrawRequest.fromBankAccountNumber();
+    this.dps_print_content = "당당페이";
+    this.fintech_use_num = openBankingWithdrawRequest.fintechUseNum();
+    this.req_client_fintech_use_num = openBankingWithdrawRequest.fintechUseNum();
+    this.tran_amt = openBankingWithdrawRequest.amount().toString();
+    this.tran_dtime = makeTranDtime();
+    this.req_client_name = openBankingWithdrawRequest.accountHolder();
+    this.req_client_num = makeBankTranId();
+    this.recv_client_name = "당당페이";
+    this.recv_client_bank_code = "088";
+    this.recv_client_account_num = "34";
   }
 }

--- a/src/main/java/com/dangdang/server/domain/pay/kftc/feignClient/dto/RequestDtoHelper.java
+++ b/src/main/java/com/dangdang/server/domain/pay/kftc/feignClient/dto/RequestDtoHelper.java
@@ -1,10 +1,12 @@
 package com.dangdang.server.domain.pay.kftc.feignClient.dto;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Random;
 
-public class BankTranIdMaker {
+public class RequestDtoHelper {
 
-  protected static String makeBankTranId() {
+  protected String makeBankTranId() {
     String tempPassword = "";
 
     for (int i = 0; i < 9; i++) {
@@ -19,5 +21,11 @@ public class BankTranIdMaker {
       }
     }
     return tempPassword;
+  }
+
+  protected String makeTranDtime() {
+    Date now = new Date();
+    SimpleDateFormat nowDate = new SimpleDateFormat("yyyyMMddHHmmss");
+    return nowDate.format(now);
   }
 }

--- a/src/test/java/com/dangdang/server/controller/pay/TestHelper.java
+++ b/src/test/java/com/dangdang/server/controller/pay/TestHelper.java
@@ -17,7 +17,7 @@ public class TestHelper {
   RedisAuthCodeRepository redisAuthCodeRepository;
 
   protected String jwtSetUp() {
-    String phoneNumber = "1";
+    String phoneNumber = "01000000003";
     MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("천호동", phoneNumber, "url",
         "닉네임");
     redisAuthCodeRepository.save(new RedisAuthCode(phoneNumber));

--- a/src/test/java/com/dangdang/server/controller/pay/payMember/PayMemberControllerTest.java
+++ b/src/test/java/com/dangdang/server/controller/pay/payMember/PayMemberControllerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -79,7 +78,7 @@ class PayMemberControllerTest extends TestHelper {
     doReturn(payResponse).when(payMemberService).charge(any(), any());
 
     mockMvc.perform(
-            patch("/pay-members/money/charge")
+            post("/pay-members/money/charge")
                 .header("AccessToken", accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("UTF-8")
@@ -122,7 +121,7 @@ class PayMemberControllerTest extends TestHelper {
     doReturn(payResponse).when(payMemberService).withdraw(any(), any());
 
     mockMvc.perform(
-            patch("/pay-members/money/withdraw")
+            post("/pay-members/money/withdraw")
                 .header("AccessToken", accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("UTF-8")

--- a/src/test/java/com/dangdang/server/domain/pay/banks/bankAccount/BankAccountServiceIntegrationTest.java
+++ b/src/test/java/com/dangdang/server/domain/pay/banks/bankAccount/BankAccountServiceIntegrationTest.java
@@ -48,13 +48,14 @@ class BankAccountServiceIntegrationTest {
   BankAccount bankAccountInactive;
   int beforeBankBalance = 1000;
   String fintechUseNum = "128947";
+  String accountHolder = "예금주명";
 
   @BeforeEach
   void setUp() {
     Member member = new Member("닉네임", "핸드폰");
     memberRepository.save(member);
 
-    payMember = new PayMember("password", member);
+    payMember = new PayMember("password", member.getId());
     payMemberRepository.save(payMember);
 
     bankAccountInactive = new BankAccount("11239847", "신한은행", 1000, payMember, "홍길동",
@@ -81,8 +82,8 @@ class BankAccountServiceIntegrationTest {
         int result = balance - amountReq;
 
         OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(
-            payMember.getId(), null, fintechUseNum, "1111", bankAccount.getAccountNumber(),
-            amountReq);
+            payMember.getId(), null, fintechUseNum, "1111", accountHolder,
+            bankAccount.getAccountNumber(), amountReq);
 
         bankAccountService.withdraw(openBankingWithdrawRequest);
 
@@ -105,7 +106,7 @@ class BankAccountServiceIntegrationTest {
         @DisplayName("InactiveBankAccountException이 발생하고")
         void inactiveBankAccountException() {
           OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(
-              payMember.getId(), null, fintechUseNum, "1111",
+              payMember.getId(), null, fintechUseNum, "1111", accountHolder,
               bankAccountInactive.getAccountNumber(), 10000);
 
           assertThrows(InactiveBankAccountException.class,
@@ -132,7 +133,8 @@ class BankAccountServiceIntegrationTest {
         void bankAccountAuthenticationException() {
           Long payMemberIdReq = Long.MAX_VALUE;
           OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(
-              payMemberIdReq, null, fintechUseNum, "11231", bankAccount.getAccountNumber(), 10000);
+              payMemberIdReq, null, fintechUseNum, "11231", accountHolder,
+              bankAccount.getAccountNumber(), 10000);
 
           assertThrows(BankAccountAuthenticationException.class,
               () -> bankAccountService.withdraw(openBankingWithdrawRequest));
@@ -158,8 +160,8 @@ class BankAccountServiceIntegrationTest {
         void insufficientBankAccountException() {
           int amountReq = beforeBankBalance + 1000;
           OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(
-              payMember.getId(), null, fintechUseNum, "1111", bankAccount.getAccountNumber(),
-              amountReq);
+              payMember.getId(), null, fintechUseNum, "1111", accountHolder,
+              bankAccount.getAccountNumber(), amountReq);
 
           assertThrows(InsufficientBankAccountException.class,
               () -> bankAccountService.withdraw(openBankingWithdrawRequest));

--- a/src/test/java/com/dangdang/server/domain/pay/banks/bankAccount/BankAccountServiceUnitTest.java
+++ b/src/test/java/com/dangdang/server/domain/pay/banks/bankAccount/BankAccountServiceUnitTest.java
@@ -38,6 +38,7 @@ class BankAccountServiceUnitTest {
   PayMember payMember;
 
   String fintechUseNum = "128947";
+  String accountHolder = "예금주명";
 
   @Nested
   @DisplayName("은행 계좌에 출금 요청이 들어왔을 때")
@@ -54,7 +55,7 @@ class BankAccountServiceUnitTest {
         int balance = 1000;
         int result = 400;
         OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(1L,
-            null, fintechUseNum, "1111", "1111", amountReq);
+            null, fintechUseNum, "1111", accountHolder, "1111", amountReq);
         BankAccount bankAccount = new BankAccount("11239847", "신한은행", balance, payMember, "홍길동");
 
         doReturn(1L).when(payMember).getId();
@@ -74,7 +75,7 @@ class BankAccountServiceUnitTest {
       @DisplayName("출금계좌에 잔액이 없다면 InsufficientBankAccountException이 발생한다.")
       void zeroBalance() {
         OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(1L,
-            null, fintechUseNum, "1111", "1111", 10000);
+            null, fintechUseNum, "1111", accountHolder, "1111", 10000);
         BankAccount bankAccount = new BankAccount("11239847", "신한은행", 0, payMember, "홍길동");
 
         doReturn(bankAccount).when(bankAccountService).findByAccountNumber(any());
@@ -88,7 +89,7 @@ class BankAccountServiceUnitTest {
       @DisplayName("출금계좌 상태가 inactive인 경우 InactiveBankAccountExceptionException이 발생한다.")
       void inactiveAccount() {
         OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(1L,
-            null, fintechUseNum, "1111", "1111", 10000);
+            null, fintechUseNum, "1111", accountHolder, "1111", 10000);
         BankAccount bankAccount = new BankAccount("11239847", "신한은행", 1000, payMember, "홍길동",
             StatusType.INACTIVE);
 
@@ -102,7 +103,7 @@ class BankAccountServiceUnitTest {
       @DisplayName("출금계좌의 payMemberId와 요청값인 payMemberId가 일치하지 않는다면 BankAccountAuthenticationException이 발생한다.")
       void failAuth() {
         OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(2L,
-            null, fintechUseNum, "1111", "1111", 10000);
+            null, fintechUseNum, "1111", accountHolder, "1111", 10000);
         BankAccount bankAccount = new BankAccount("11239847", "신한은행", 1000, payMember, "홍길동");
 
         doReturn(bankAccount).when(bankAccountService).findByAccountNumber(any());

--- a/src/test/java/com/dangdang/server/domain/pay/daangnpay/connectionAccount/ConnectionAccountServiceTest.java
+++ b/src/test/java/com/dangdang/server/domain/pay/daangnpay/connectionAccount/ConnectionAccountServiceTest.java
@@ -55,7 +55,7 @@ class ConnectionAccountServiceTest {
     memberRepository.save(member);
 
     String password = "password123";
-    payMember = new PayMember(password, member);
+    payMember = new PayMember(password, member.getId());
     payMemberRepository.save(payMember);
 
     BankAccount bankAccount1 = new BankAccount("12383461723", "신한은행", 500000, payMember, "홍길동");

--- a/src/test/java/com/dangdang/server/domain/pay/daangnpay/payMember/PayMemberRepositoryTest.java
+++ b/src/test/java/com/dangdang/server/domain/pay/daangnpay/payMember/PayMemberRepositoryTest.java
@@ -27,11 +27,11 @@ class PayMemberRepositoryTest {
     memberRepository.save(member);
 
     String password = "password123";
-    PayMember payMember = new PayMember(password, member);
+    PayMember payMember = new PayMember(password, member.getId());
     payMemberRepository.save(payMember);
 
     PayMember findPayMember = payMemberRepository.findByMemberId(member.getId()).get();
 
-    Assertions.assertThat(findPayMember.getMember().getId()).isEqualTo(member.getId());
+    Assertions.assertThat(findPayMember.getMemberId()).isEqualTo(member.getId());
   }
 }

--- a/src/test/java/com/dangdang/server/domain/pay/daangnpay/payMember/PayMemberServiceIntegrationTest.java
+++ b/src/test/java/com/dangdang/server/domain/pay/daangnpay/payMember/PayMemberServiceIntegrationTest.java
@@ -55,7 +55,7 @@ class PayMemberServiceIntegrationTest {
     memberRepository.save(member);
 
     String password = "password123";
-    payMember = new PayMember(password, payMemberMoney, member);
+    payMember = new PayMember(password, payMemberMoney, member.getId());
     payMemberRepository.save(payMember);
 
     BankAccount bankAccount1 = new BankAccount("12383461723", "신한은행", 500000, payMember, "홍길동");

--- a/src/test/java/com/dangdang/server/domain/pay/daangnpay/payMember/PayMemberServiceUnitTest.java
+++ b/src/test/java/com/dangdang/server/domain/pay/daangnpay/payMember/PayMemberServiceUnitTest.java
@@ -70,7 +70,7 @@ public class PayMemberServiceUnitTest {
       OpenBankingInquiryReceiveResponse openBankingInquiryReceiveResponse = new OpenBankingInquiryReceiveResponse(
           1L, null, "신한은행", "홍길동", "38471032472", LocalDateTime.now());
       GetConnectionAccountReceiveResponse getConnectionAccountReceiveResponse = new GetConnectionAccountReceiveResponse(
-          true, "하나은행", "234719284");
+          true, "홍길동", "하나은행", "234719284");
 
       doReturn(Optional.of(payMember)).when(payMemberRepository).findByMemberId(any());
       doReturn(openBankingInquiryReceiveResponse).when(openBankingFacadeService)

--- a/src/test/java/com/dangdang/server/domain/pay/daangnpay/payUsageHistory/PayUsageHistoryServiceIntegrationTest.java
+++ b/src/test/java/com/dangdang/server/domain/pay/daangnpay/payUsageHistory/PayUsageHistoryServiceIntegrationTest.java
@@ -42,7 +42,7 @@ class PayUsageHistoryServiceIntegrationTest {
     memberRepository.save(member);
 
     String password = "password123";
-    payMember = new PayMember(password, member);
+    payMember = new PayMember(password, member.getId());
     payMemberRepository.save(payMember);
   }
 

--- a/src/test/java/com/dangdang/server/domain/pay/kftc/openBankingFacade/OpenBankingFacadeServiceIntegrationTest.java
+++ b/src/test/java/com/dangdang/server/domain/pay/kftc/openBankingFacade/OpenBankingFacadeServiceIntegrationTest.java
@@ -60,13 +60,14 @@ class OpenBankingFacadeServiceIntegrationTest {
   TrustAccount trustAccountInactive;
 
   String fintechUseNum = "128947";
+  String accountHolder = "예금주명";
 
   @BeforeEach
   void setUp() {
     Member member = new Member("닉네임", "핸드폰");
     memberRepository.save(member);
 
-    payMember = new PayMember("password", member);
+    payMember = new PayMember("password", member.getId());
     payMemberRepository.save(payMember);
 
     trustAccount = new TrustAccount("257182", 100000, "당근페이_신탁");
@@ -105,7 +106,7 @@ class OpenBankingFacadeServiceIntegrationTest {
         int resultTrust = beforeTrustBalance + amountReq;
 
         OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(
-            payMember.getId(), null, fintechUseNum, trustAccount.getAccountNumber(),
+            payMember.getId(), null, fintechUseNum, trustAccount.getAccountNumber(), accountHolder,
             bankAccount.getAccountNumber(), amountReq);
 
         openBankingFacadeService.withdraw(openBankingWithdrawRequest);
@@ -141,7 +142,7 @@ class OpenBankingFacadeServiceIntegrationTest {
 
           OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(
               payMember.getId(), null, fintechUseNum, trustAccount.getAccountNumber(),
-              zeroBankAccount.getAccountNumber(), 10000);
+              accountHolder, zeroBankAccount.getAccountNumber(), 10000);
 
           assertThrows(InsufficientBankAccountException.class,
               () -> openBankingFacadeService.withdraw(openBankingWithdrawRequest));
@@ -180,7 +181,7 @@ class OpenBankingFacadeServiceIntegrationTest {
 
           OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(
               payMember.getId(), null, fintechUseNum, trustAccount.getAccountNumber(),
-              inactiveBankAccount.getAccountNumber(), 10000);
+              accountHolder, inactiveBankAccount.getAccountNumber(), 10000);
 
           assertThrows(InactiveBankAccountException.class,
               () -> openBankingFacadeService.withdraw(openBankingWithdrawRequest));
@@ -210,7 +211,7 @@ class OpenBankingFacadeServiceIntegrationTest {
           beforeTrustBalance = trustAccount.getBalance();
 
           OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(
-              payMemberIdReq, null, fintechUseNum, trustAccount.getAccountNumber(),
+              payMemberIdReq, null, fintechUseNum, trustAccount.getAccountNumber(), accountHolder,
               bankAccount.getAccountNumber(), 10000);
 
           assertThrows(BankAccountAuthenticationException.class,
@@ -241,7 +242,7 @@ class OpenBankingFacadeServiceIntegrationTest {
 
           OpenBankingWithdrawRequest openBankingWithdrawRequest = new OpenBankingWithdrawRequest(
               payMember.getId(), null, fintechUseNum, trustAccountInactive.getAccountNumber(),
-              bankAccount.getAccountNumber(), 10000);
+              accountHolder, bankAccount.getAccountNumber(), 10000);
 
           assertThrows(InactiveTrustAccountException.class,
               () -> openBankingFacadeService.withdraw(openBankingWithdrawRequest));


### PR DESCRIPTION
### 변경 내용 요약
- 수취 조회 API 외부 연동 구현

### 작업한 내용
- PayMember 엔티티에서 Member와의 연관관계를 제거했어요.
- 수취 조회 API에 외부 오픈API 연동 환경을 추가했어요.

### 관련 링크
- [지라 티켓](https://cloudwi.atlassian.net/jira/software/projects/TRYC/boards/1/backlog?selectedIssue=TRYC-169) <!-- 괄호 안에 지라 티켓 링크 넣어주세요. -->