### PR TITLE
[TRYC-72] 전체 채팅방 목록 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/chat.adoc
+++ b/src/docs/asciidoc/chat.adoc
@@ -1,0 +1,17 @@
+== 채팅방
+=== 채팅방 생성
+=== api/v1/chat-room
+
+.Request
+include::{snippets}/api/v1/post/chat-room/http-request.adoc[]
+
+.Response
+include::{snippets}/api/v1/post/chat-room/http-response.adoc[]
+
+=== 채팅방 조회
+.Request
+include::{snippets}/api/v1/get/chat-room/http-request.adoc[]
+include::{snippets}/api/v1/get/chat-room/request-headers.adoc[]
+
+.Response
+include::{snippets}/api/v1/get/chat-room/http-response.adoc[]

--- a/src/main/java/com/dangdang/server/controller/chat/ChatMessageController.java
+++ b/src/main/java/com/dangdang/server/controller/chat/ChatMessageController.java
@@ -1,5 +1,6 @@
 package com.dangdang.server.controller.chat;
 
+import com.dangdang.server.domain.message.application.ChatMessageService;
 import com.dangdang.server.domain.message.dto.ChatMessage;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -9,13 +10,17 @@ import org.springframework.stereotype.Controller;
 public class ChatMessageController {
 
   private final SimpMessagingTemplate template;
+  private final ChatMessageService chatMessageService;
 
-  public ChatMessageController(SimpMessagingTemplate template) {
+  public ChatMessageController(SimpMessagingTemplate template,
+      ChatMessageService chatMessageService) {
     this.template = template;
+    this.chatMessageService = chatMessageService;
   }
 
   @MessageMapping("/message")
   public void message(ChatMessage chatMessage) {
+    // TODO message DB에 저장
     template.convertAndSend("/subscribe/chat/room/" + chatMessage.chatRoomId(), chatMessage);
   }
 }

--- a/src/main/java/com/dangdang/server/controller/chat/ChatRoomController.java
+++ b/src/main/java/com/dangdang/server/controller/chat/ChatRoomController.java
@@ -4,7 +4,10 @@ import com.dangdang.server.domain.chatroom.application.ChatRoomService;
 import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
 import com.dangdang.server.domain.chatroom.dto.request.ChatRoomSaveRequest;
 import com.dangdang.server.domain.chatroom.dto.response.ChatRoomSaveResponse;
+import com.dangdang.server.domain.chatroom.dto.response.ChatRoomsResponse;
+import com.dangdang.server.global.aop.CurrentUserId;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,4 +32,13 @@ public class ChatRoomController {
     );
     return ResponseEntity.ok(chatRoomSaveResponse);
   }
+
+  @CurrentUserId
+  @GetMapping("/chat-room")
+  public ResponseEntity<ChatRoomsResponse> listChatRooms(Long memberId) {
+    ChatRoomsResponse chatRoomsResponse = chatRoomService.findChatRooms(memberId);
+    return ResponseEntity.ok(chatRoomsResponse);
+  }
+
+  // TODO roomID 로 접근했을 때 기록된 메세지들 오래된 순서부터 조회 API
 }

--- a/src/main/java/com/dangdang/server/domain/chatroom/application/ChatRoomService.java
+++ b/src/main/java/com/dangdang/server/domain/chatroom/application/ChatRoomService.java
@@ -3,6 +3,8 @@ package com.dangdang.server.domain.chatroom.application;
 import com.dangdang.server.domain.chatroom.domain.ChatRoomRepository;
 import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
 import com.dangdang.server.domain.chatroom.dto.request.ChatRoomSaveRequest;
+import com.dangdang.server.domain.chatroom.dto.response.ChatRoomResponse;
+import com.dangdang.server.domain.chatroom.dto.response.ChatRoomsResponse;
 import com.dangdang.server.domain.member.domain.MemberRepository;
 import com.dangdang.server.domain.member.domain.entity.Member;
 import com.dangdang.server.domain.member.exception.MemberNotFoundException;
@@ -10,6 +12,9 @@ import com.dangdang.server.domain.post.domain.PostRepository;
 import com.dangdang.server.domain.post.domain.entity.Post;
 import com.dangdang.server.domain.post.exception.PostNotFoundException;
 import com.dangdang.server.global.exception.ExceptionCode;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,5 +48,46 @@ public class ChatRoomService {
     ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
 
     return savedChatRoom;
+  }
+
+  @Transactional
+  public ChatRoomsResponse findChatRooms(Long memberId) {
+    List<ChatRoom> chatRoomsByMemberId = chatRoomRepository.findByBuyerIdOrSellerId(memberId);
+
+    List<ChatRoomResponse> chatRoomResponseList = new ArrayList<>();
+
+    for (ChatRoom chatRoom : chatRoomsByMemberId) {
+      Long chatRoomId = chatRoom.getId();
+      String townName = chatRoom.getPost().getTownName();
+      int size = chatRoom.getMessageList().size();
+      String recentMessage = size != 0 ? chatRoom.getMessageList().get(size - 1).getMessage() : null;
+      LocalDateTime recentMessageCreatedAt = size != 0 ? chatRoom.getMessageList().get(size - 1).getCreatedAt() : null;
+      // 자기 자신이 buyer 일 때 -> seller
+      ChatRoomResponse chatRoomResponse;
+      if (chatRoom.getBuyer().getId() == memberId) {
+        chatRoomResponse = new ChatRoomResponse(
+            chatRoomId,
+            chatRoom.getSeller().getProfileImgUrl(),
+            chatRoom.getSeller().getNickname(),
+            townName,
+            recentMessage,
+            recentMessageCreatedAt
+        );
+      }
+      // 자기 자신이 seller 일 때 -> buyer
+      else {
+        chatRoomResponse = new ChatRoomResponse(
+            chatRoomId,
+            chatRoom.getBuyer().getProfileImgUrl(),
+            chatRoom.getBuyer().getNickname(),
+            townName,
+            recentMessage,
+            recentMessageCreatedAt
+        );
+      }
+      chatRoomResponseList.add(chatRoomResponse);
+    }
+
+    return new ChatRoomsResponse(chatRoomResponseList);
   }
 }

--- a/src/main/java/com/dangdang/server/domain/chatroom/domain/ChatRoomRepository.java
+++ b/src/main/java/com/dangdang/server/domain/chatroom/domain/ChatRoomRepository.java
@@ -1,8 +1,11 @@
 package com.dangdang.server.domain.chatroom.domain;
 
 import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-
+  @Query("select c from ChatRoom c where c.buyer.id = :memberId or c.seller.id = :memberId")
+  List<ChatRoom> findByBuyerIdOrSellerId(Long memberId);
 }

--- a/src/main/java/com/dangdang/server/domain/chatroom/dto/response/ChatRoomResponse.java
+++ b/src/main/java/com/dangdang/server/domain/chatroom/dto/response/ChatRoomResponse.java
@@ -1,0 +1,13 @@
+package com.dangdang.server.domain.chatroom.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomResponse(
+    Long roomId,
+    String profileImage,
+    String nickName,
+    String townName,
+    String recentMessage,
+    LocalDateTime recentMessageCreatedAt) {
+
+}

--- a/src/main/java/com/dangdang/server/domain/chatroom/dto/response/ChatRoomsResponse.java
+++ b/src/main/java/com/dangdang/server/domain/chatroom/dto/response/ChatRoomsResponse.java
@@ -1,0 +1,7 @@
+package com.dangdang.server.domain.chatroom.dto.response;
+
+import java.util.List;
+
+public record ChatRoomsResponse(List<ChatRoomResponse> chatRoomResponseList) {
+
+}

--- a/src/main/java/com/dangdang/server/domain/message/application/ChatMessageService.java
+++ b/src/main/java/com/dangdang/server/domain/message/application/ChatMessageService.java
@@ -1,0 +1,8 @@
+package com.dangdang.server.domain.message.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChatMessageService {
+
+}

--- a/src/main/java/com/dangdang/server/domain/message/domain/MessageRepository.java
+++ b/src/main/java/com/dangdang/server/domain/message/domain/MessageRepository.java
@@ -1,0 +1,8 @@
+package com.dangdang.server.domain.message.domain;
+
+import com.dangdang.server.domain.message.domain.entity.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+
+}

--- a/src/main/java/com/dangdang/server/domain/message/domain/entity/Message.java
+++ b/src/main/java/com/dangdang/server/domain/message/domain/entity/Message.java
@@ -31,7 +31,7 @@ public class Message extends BaseEntity {
   @Column(name = "message")
   private String message;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "chat_room_id")
   private ChatRoom chatRoom;
 

--- a/src/test/java/com/dangdang/server/controller/chat/ChatRoomControllerTest.java
+++ b/src/test/java/com/dangdang/server/controller/chat/ChatRoomControllerTest.java
@@ -1,6 +1,9 @@
 package com.dangdang.server.controller.chat;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -11,6 +14,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.dangdang.server.domain.chatroom.domain.ChatRoomRepository;
+import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
 import com.dangdang.server.domain.chatroom.dto.request.ChatRoomSaveRequest;
 import com.dangdang.server.domain.member.domain.MemberRepository;
 import com.dangdang.server.domain.member.domain.entity.Member;
@@ -19,6 +24,7 @@ import com.dangdang.server.domain.post.domain.PostRepository;
 import com.dangdang.server.domain.post.domain.entity.Post;
 import com.dangdang.server.domain.town.domain.TownRepository;
 import com.dangdang.server.domain.town.domain.entity.Town;
+import com.dangdang.server.global.security.JwtTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,6 +33,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,6 +56,12 @@ class ChatRoomControllerTest {
 
   @Autowired
   PostRepository postRepository;
+
+  @Autowired
+  ChatRoomRepository chatRoomRepository;
+
+  @Autowired
+  JwtTokenProvider jwtTokenProvider;
 
   @Test
   @DisplayName("채팅 방 생성 성공")
@@ -74,7 +87,7 @@ class ChatRoomControllerTest {
             .content(objectMapper.writeValueAsString(chatRoomSaveRequest)))
         .andExpect(status().isOk())
         .andDo(
-            document("api/v1/chat-room",
+            document("api/v1/post/chat-room",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 requestFields(
@@ -115,5 +128,59 @@ class ChatRoomControllerTest {
         .andExpect(status().isNotFound())
         .andDo(print());
 
+  }
+
+  @Test
+  @DisplayName("채팅 방 조회 성공")
+  @Transactional
+  void findChatRooms_success() throws Exception {
+    Member buyer1 = new Member("01012345677", "buyer1");
+    Member buyer2 = new Member("01012345678", "buyer2");
+    Member buyer3 = new Member("01012345679", "buyer3");
+    Member seller = new Member("01087654321", "seller");
+    Town sellerTown = new Town("내동네", null, null);
+
+    Post post = new Post("에어팟", "에어팟 팝니다", Category.디지털기기, null,
+        null, null, null,
+        0, false, seller, sellerTown, null, null);
+
+    memberRepository.save(buyer1);
+    memberRepository.save(buyer2);
+    memberRepository.save(buyer3);
+    Member savedSeller = memberRepository.save(seller);
+    townRepository.save(sellerTown);
+    postRepository.save(post);
+
+    ChatRoom chatRoom1 = new ChatRoom(buyer1, seller, post);
+    ChatRoom chatRoom2 = new ChatRoom(buyer2, seller, post);
+    ChatRoom chatRoom3 = new ChatRoom(buyer3, seller, post);
+
+    chatRoomRepository.save(chatRoom1);
+    chatRoomRepository.save(chatRoom2);
+    chatRoomRepository.save(chatRoom3);
+
+    String accessToken = "Bearer " + jwtTokenProvider.createAccessToken(savedSeller.getId());
+
+    mockMvc.perform(get("/chat-room")
+            .header("AccessToken",accessToken)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andDo(
+            document("api/v1/get/chat-room",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                    headerWithName("AccessToken").description("Access Token")
+                ),
+                responseFields(
+                    fieldWithPath("chatRoomResponseList[]").type(JsonFieldType.ARRAY).description("채팅방 조회 목록 리스트"),
+                    fieldWithPath("chatRoomResponseList[].roomId").description("채팅방 아이디"),
+                    fieldWithPath("chatRoomResponseList[].profileImage").description("대화 상대방 프로필 이미지"),
+                    fieldWithPath("chatRoomResponseList[].nickName").description("대화 상대방 닉네임"),
+                    fieldWithPath("chatRoomResponseList[].townName").description("판매글 동네이름"),
+                    fieldWithPath("chatRoomResponseList[].recentMessage").description("최근 메세지"),
+                    fieldWithPath("chatRoomResponseList[].recentMessageCreatedAt").description("최근 메세지 시각")
+                )
+            ));
   }
 }

--- a/src/test/java/com/dangdang/server/domain/chatroom/application/ChatRoomServiceTest.java
+++ b/src/test/java/com/dangdang/server/domain/chatroom/application/ChatRoomServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.dangdang.server.domain.chatroom.domain.ChatRoomRepository;
 import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
 import com.dangdang.server.domain.chatroom.dto.request.ChatRoomSaveRequest;
+import com.dangdang.server.domain.chatroom.dto.response.ChatRoomsResponse;
 import com.dangdang.server.domain.member.domain.MemberRepository;
 import com.dangdang.server.domain.member.domain.entity.Member;
 import com.dangdang.server.domain.post.domain.Category;
@@ -38,6 +39,7 @@ class ChatRoomServiceTest {
 
   @Autowired
   PostRepository postRepository;
+
 
   @Test
   @DisplayName("채팅방 생성이 성공적인 경우")
@@ -84,4 +86,44 @@ class ChatRoomServiceTest {
         .isInstanceOf(PostNotFoundException.class);
   }
 
+  @Test
+  @DisplayName("채팅방 조회 성공")
+  void findChatRooms_success() {
+    // chatRoom 생성 필요
+    // 1. member 2명 생성 필요
+    // 2. post 생성 필요 -> town 생성 필요
+
+    // 3. buyer 달리해서 ChatRoom 만들기
+
+    Member buyer1 = new Member("01012345677", "buyer1");
+    Member buyer2 = new Member("01012345678", "buyer2");
+    Member buyer3 = new Member("01012345679", "buyer3");
+    Member seller = new Member("01087654321", "seller");
+    Town sellerTown = new Town("내동네", null, null);
+
+    Post post = new Post("에어팟", "에어팟 팝니다", Category.디지털기기, null,
+        null, null, null,
+        0, false, seller, sellerTown, null, null);
+
+    memberRepository.save(buyer1);
+    memberRepository.save(buyer2);
+    memberRepository.save(buyer3);
+    Member savedSeller = memberRepository.save(seller);
+    townRepository.save(sellerTown);
+    postRepository.save(post);
+
+    ChatRoom chatRoom1 = new ChatRoom(buyer1, seller, post);
+    ChatRoom chatRoom2 = new ChatRoom(buyer2, seller, post);
+    ChatRoom chatRoom3 = new ChatRoom(buyer3, seller, post);
+
+    chatRoomRepository.save(chatRoom1);
+    chatRoomRepository.save(chatRoom2);
+    chatRoomRepository.save(chatRoom3);
+
+    // when
+    ChatRoomsResponse chatRoomsResponse = chatRoomService.findChatRooms(savedSeller.getId());
+
+    // then
+    assertThat(chatRoomsResponse.chatRoomResponseList().size()).isEqualTo(3);
+  }
 }


### PR DESCRIPTION
### 변경 내용 요약
채팅방 목록 조회 API 구현하였습니다

### 작업한 내용
- 채팅방 목록 조회 구현하였습니다 
  - 방 번호
  - 상대방 프로필 이미지
  - 상대방 닉네임
  - 게시글 동네 이름
  - 최근 메세지
  - 최근 메세지 생성 시각
- 성공 경우에 대해서 test 코드 작성하고 REST-Docs 작성 완료하였습니다

### 관련 링크
- [TRYC-72](https://cloudwi.atlassian.net/browse/TRYC-72) <!-- 괄호 안에 지라 티켓 링크 넣어주세요. -->



[TRYC-72]: https://cloudwi.atlassian.net/browse/TRYC-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ