### PR TITLE
[TRYC-73] 채팅 주고 받기 

### DIFF
--- a/src/docs/asciidoc/chat.adoc
+++ b/src/docs/asciidoc/chat.adoc
@@ -9,9 +9,21 @@ include::{snippets}/api/v1/post/chat-room/http-request.adoc[]
 include::{snippets}/api/v1/post/chat-room/http-response.adoc[]
 
 === 채팅방 조회
+=== api/v1/chat-room
 .Request
 include::{snippets}/api/v1/get/chat-room/http-request.adoc[]
 include::{snippets}/api/v1/get/chat-room/request-headers.adoc[]
 
 .Response
 include::{snippets}/api/v1/get/chat-room/http-response.adoc[]
+
+== 채팅방 메세지
+=== 채팅방 메세지 조회
+=== api/v1/chat-room/{room_id}
+
+.Request
+include::{snippets}/api/v1/get/chat-room/message/http-request.adoc[]
+include::{snippets}/api/v1/get/chat-room/message/request-headers.adoc[]
+
+.Response
+include::{snippets}/api/v1/get/chat-room/message/http-response.adoc[]

--- a/src/docs/asciidoc/member-town.adoc
+++ b/src/docs/asciidoc/member-town.adoc
@@ -61,13 +61,4 @@ include::{snippets}/api/v1/post/member-town/certification/request-fields.adoc[]
 .Response
 include::{snippets}/api/v1/post/member-town/certification/http-response.adoc[]
 
-== 채팅방
-=== 채팅방 생성
-=== api/v1/chat-room
-
-.Request
-include::{snippets}/api/v1/chat-room/http-request.adoc[]
-
-.Response
-include::{snippets}/api/v1/chat-room/http-response.adoc[]
 

--- a/src/main/java/com/dangdang/server/controller/chat/ChatMessageController.java
+++ b/src/main/java/com/dangdang/server/controller/chat/ChatMessageController.java
@@ -2,9 +2,14 @@ package com.dangdang.server.controller.chat;
 
 import com.dangdang.server.domain.message.application.ChatMessageService;
 import com.dangdang.server.domain.message.dto.ChatMessage;
+import com.dangdang.server.domain.message.dto.response.ChatMessagesResponse;
+import com.dangdang.server.global.aop.CurrentUserId;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Controller
 public class ChatMessageController {
@@ -20,7 +25,16 @@ public class ChatMessageController {
 
   @MessageMapping("/message")
   public void message(ChatMessage chatMessage) {
-    // TODO message DB에 저장
+    // message DB 에 저장
+    chatMessageService.saveChatMessage(chatMessage);
     template.convertAndSend("/subscribe/chat/room/" + chatMessage.chatRoomId(), chatMessage);
+  }
+
+  // 상세 채팅방 메세지 조회, 오래된 순서부터 조회
+  @CurrentUserId
+  @GetMapping("/chat-room/{room_id}")
+  public ResponseEntity<ChatMessagesResponse> findChatMessages(@PathVariable("room_id") Long chatRoomId) {
+    ChatMessagesResponse chatMessages = chatMessageService.findChatMessages(chatRoomId);
+    return ResponseEntity.ok(chatMessages);
   }
 }

--- a/src/main/java/com/dangdang/server/controller/chat/ChatRoomController.java
+++ b/src/main/java/com/dangdang/server/controller/chat/ChatRoomController.java
@@ -5,6 +5,7 @@ import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
 import com.dangdang.server.domain.chatroom.dto.request.ChatRoomSaveRequest;
 import com.dangdang.server.domain.chatroom.dto.response.ChatRoomSaveResponse;
 import com.dangdang.server.domain.chatroom.dto.response.ChatRoomsResponse;
+import com.dangdang.server.domain.message.application.ChatMessageService;
 import com.dangdang.server.global.aop.CurrentUserId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,10 +36,8 @@ public class ChatRoomController {
 
   @CurrentUserId
   @GetMapping("/chat-room")
-  public ResponseEntity<ChatRoomsResponse> listChatRooms(Long memberId) {
+  public ResponseEntity<ChatRoomsResponse> findChatRooms(Long memberId) {
     ChatRoomsResponse chatRoomsResponse = chatRoomService.findChatRooms(memberId);
     return ResponseEntity.ok(chatRoomsResponse);
   }
-
-  // TODO roomID 로 접근했을 때 기록된 메세지들 오래된 순서부터 조회 API
 }

--- a/src/main/java/com/dangdang/server/controller/memberTown/MemberTownController.java
+++ b/src/main/java/com/dangdang/server/controller/memberTown/MemberTownController.java
@@ -1,6 +1,5 @@
 package com.dangdang.server.controller.memberTown;
 
-import com.dangdang.server.domain.member.domain.entity.Member;
 import com.dangdang.server.domain.memberTown.application.MemberTownService;
 import com.dangdang.server.domain.memberTown.dto.request.MemberTownCertifyRequest;
 import com.dangdang.server.domain.memberTown.dto.request.MemberTownRangeRequest;
@@ -8,9 +7,9 @@ import com.dangdang.server.domain.memberTown.dto.request.MemberTownRequest;
 import com.dangdang.server.domain.memberTown.dto.response.MemberTownCertifyResponse;
 import com.dangdang.server.domain.memberTown.dto.response.MemberTownRangeResponse;
 import com.dangdang.server.domain.memberTown.dto.response.MemberTownResponse;
+import com.dangdang.server.global.aop.CurrentUserId;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -28,46 +27,47 @@ public class MemberTownController {
     this.memberTownService = memberTownService;
   }
 
+  @CurrentUserId
   @PostMapping
   public ResponseEntity<MemberTownResponse> createMemberTown(
-      @RequestBody @Valid MemberTownRequest memberTownRequest,
-      Authentication authentication) {
-    MemberTownResponse memberTownSaveResponse = memberTownService.createMemberTown(memberTownRequest,
-        (Member) authentication.getPrincipal());
+      @RequestBody @Valid MemberTownRequest memberTownRequest, Long memberId) {
+    MemberTownResponse memberTownSaveResponse = memberTownService.createMemberTown(
+        memberTownRequest, memberId);
     return ResponseEntity.ok(memberTownSaveResponse);
   }
 
+  @CurrentUserId
   @DeleteMapping
   public void deleteMemberTown(
-      @RequestBody @Valid MemberTownRequest memberTownRequest,
-      Authentication authentication) {
-     memberTownService.deleteMemberTown(memberTownRequest, (Member) authentication.getPrincipal());
+      @RequestBody @Valid MemberTownRequest memberTownRequest, Long memberId) {
+    memberTownService.deleteMemberTown(memberTownRequest, memberId);
   }
 
+  @CurrentUserId
   @PutMapping("/active")
   public ResponseEntity<MemberTownResponse> changeActiveMemberTown(
-      @RequestBody @Valid MemberTownRequest memberTownRequest,
-      Authentication authentication) {
-    MemberTownResponse memberTownResponse = memberTownService.changeActiveMemberTown(
-        memberTownRequest, (Member) authentication.getPrincipal());
+      @RequestBody @Valid MemberTownRequest memberTownRequest, Long memberId) {
+    MemberTownResponse memberTownResponse = memberTownService
+        .changeActiveMemberTown(memberTownRequest, memberId);
     return ResponseEntity.ok(memberTownResponse);
   }
 
+  @CurrentUserId
   @PutMapping("/range")
   public ResponseEntity<MemberTownRangeResponse> changeMemberTownRange(
-      @RequestBody @Valid MemberTownRangeRequest memberTownRangeRequest,
-      Authentication authentication) {
+      @RequestBody @Valid MemberTownRangeRequest memberTownRangeRequest, Long memberId) {
     MemberTownRangeResponse memberTownRangeResponse = memberTownService
-        .changeMemberTownRange(memberTownRangeRequest, (Member) authentication.getPrincipal());
+        .changeMemberTownRange(memberTownRangeRequest, memberId);
 
     return ResponseEntity.ok(memberTownRangeResponse);
   }
 
+  @CurrentUserId
   @PostMapping("/certification")
   public ResponseEntity<MemberTownCertifyResponse> certifyMemberTown(@RequestBody
-  MemberTownCertifyRequest memberTownCertifyRequest, Authentication authentication) {
+  MemberTownCertifyRequest memberTownCertifyRequest, Long memberId) {
     MemberTownCertifyResponse memberTownCertifyResponse = memberTownService
-        .certifyMemberTown(memberTownCertifyRequest, (Member) authentication.getPrincipal());
+        .certifyMemberTown(memberTownCertifyRequest, memberId);
     return ResponseEntity.ok(memberTownCertifyResponse);
   }
 }

--- a/src/main/java/com/dangdang/server/domain/chatroom/application/ChatRoomService.java
+++ b/src/main/java/com/dangdang/server/domain/chatroom/application/ChatRoomService.java
@@ -90,4 +90,5 @@ public class ChatRoomService {
 
     return new ChatRoomsResponse(chatRoomResponseList);
   }
+
 }

--- a/src/main/java/com/dangdang/server/domain/chatroom/domain/entity/ChatRoom.java
+++ b/src/main/java/com/dangdang/server/domain/chatroom/domain/entity/ChatRoom.java
@@ -9,6 +9,7 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -38,7 +39,7 @@ public class ChatRoom extends BaseEntity {
   @JoinColumn(name = "post_id")
   private Post post;
 
-  @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL ,fetch = FetchType.EAGER)
   List<Message> messageList = new ArrayList<>();
 
   protected ChatRoom() {

--- a/src/main/java/com/dangdang/server/domain/chatroom/exception/ChatRoomNotFoundException.java
+++ b/src/main/java/com/dangdang/server/domain/chatroom/exception/ChatRoomNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dangdang.server.domain.chatroom.exception;
+
+import com.dangdang.server.global.exception.BusinessException;
+import com.dangdang.server.global.exception.ExceptionCode;
+
+public class ChatRoomNotFoundException extends BusinessException {
+
+  public ChatRoomNotFoundException(ExceptionCode exceptionCode) {
+    super(exceptionCode);
+  }
+}

--- a/src/main/java/com/dangdang/server/domain/memberTown/application/MemberTownService.java
+++ b/src/main/java/com/dangdang/server/domain/memberTown/application/MemberTownService.java
@@ -43,16 +43,16 @@ public class MemberTownService {
 
 
   @Transactional
-  public MemberTownResponse createMemberTown(MemberTownRequest memberTownRequest, Member member) {
+  public MemberTownResponse createMemberTown(MemberTownRequest memberTownRequest, Long memberId) {
 
     // 반드시 memberTown 개수가 1인 경우에만 추가 가능
-    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(member.getId());
+    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(memberId);
     if (memberTownList.size() != 1) {
       throw new NotAppropriateCountException(ExceptionCode.NOT_APPROPRIATE_COUNT);
     }
 
     Town foundTown = getTownByTownName(memberTownRequest.townName());
-    Member foundMember = getMemberByMemberId(member.getId());
+    Member foundMember = getMemberByMemberId(memberId);
 
     MemberTown memberTown = new MemberTown(foundMember, foundTown);
 
@@ -65,9 +65,9 @@ public class MemberTownService {
   }
 
   @Transactional
-  public void deleteMemberTown(MemberTownRequest memberTownRequest, Member member) {
+  public void deleteMemberTown(MemberTownRequest memberTownRequest, Long memberId) {
     // MemberTown 이 2개 있어야만 삭제가 가능하다
-    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(member.getId());
+    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(memberId);
     if (memberTownList.size() != 2) {
       throw new NotAppropriateCountException(ExceptionCode.NOT_APPROPRIATE_COUNT);
     }
@@ -93,12 +93,11 @@ public class MemberTownService {
   }
 
   @Transactional
-  public MemberTownResponse changeActiveMemberTown(MemberTownRequest memberTownRequest,
-      Member member) {
+  public MemberTownResponse changeActiveMemberTown(MemberTownRequest memberTownRequest, Long memberId) {
     // 상대편은 Inactive, 입력 들어오면 Active
     // member 가 DB에 저장될 때 id를 반드시 가지고 있어야 한다
     // 이 메서드는 front 코드에서 모두 2개의 값이 있을 때 활성화 되야 함
-    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(member.getId());
+    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(memberId);
     if (memberTownList.size() != 2) {
       throw new NotAppropriateCountException(ExceptionCode.NOT_APPROPRIATE_COUNT);
     }
@@ -115,8 +114,8 @@ public class MemberTownService {
 
   @Transactional
   public MemberTownRangeResponse changeMemberTownRange(
-      MemberTownRangeRequest memberTownRangeRequest, Member member) {
-    Member foundMember = getMemberByMemberId(member.getId());
+      MemberTownRangeRequest memberTownRangeRequest, Long memberId) {
+    Member foundMember = getMemberByMemberId(memberId);
     Town foundTown = getTownByTownName(memberTownRangeRequest.townName());
 
     MemberTown foundMemberTown = memberTownRepository
@@ -132,7 +131,7 @@ public class MemberTownService {
 
   @Transactional
   public MemberTownCertifyResponse certifyMemberTown(
-      MemberTownCertifyRequest memberTownCertifyRequest, Member member) {
+      MemberTownCertifyRequest memberTownCertifyRequest, Long memberId) {
     boolean isCertified = false;
     // 1. 현재 위도, 경도를 기준으로 Town list 조회
     List<AdjacentTownResponse> towns = townRepository.findAdjacentTownsByPoint(
@@ -140,7 +139,7 @@ public class MemberTownService {
         memberTownCertifyRequest.longitude(),
         MY_TOWN_CERTIFY_DISTANCE);
     // 2. Active 로 설정한 동네가 list 안에 있는지 확인
-    MemberTown activeMemberTown = memberTownRepository.findByMemberId(member.getId())
+    MemberTown activeMemberTown = memberTownRepository.findByMemberId(memberId)
         .stream()
         .filter(memberTown -> memberTown.getStatus() == StatusType.ACTIVE)
         .findFirst()

--- a/src/main/java/com/dangdang/server/domain/message/application/ChatMessageService.java
+++ b/src/main/java/com/dangdang/server/domain/message/application/ChatMessageService.java
@@ -1,8 +1,46 @@
 package com.dangdang.server.domain.message.application;
 
+import com.dangdang.server.domain.chatroom.domain.ChatRoomRepository;
+import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
+import com.dangdang.server.domain.chatroom.exception.ChatRoomNotFoundException;
+import com.dangdang.server.domain.message.domain.MessageRepository;
+import com.dangdang.server.domain.message.domain.entity.Message;
+import com.dangdang.server.domain.message.dto.ChatMessage;
+import com.dangdang.server.domain.message.dto.response.ChatMessagesResponse;
+import com.dangdang.server.global.exception.ExceptionCode;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ChatMessageService {
 
+  private final MessageRepository messageRepository;
+  private final ChatRoomRepository chatRoomRepository;
+
+  public ChatMessageService(MessageRepository messageRepository,
+      ChatRoomRepository chatRoomRepository) {
+    this.messageRepository = messageRepository;
+    this.chatRoomRepository = chatRoomRepository;
+  }
+
+  @Transactional
+  public void saveChatMessage(ChatMessage chatMessage) {
+    ChatRoom chatRoom = chatRoomRepository.findById(chatMessage.chatRoomId())
+        .orElseThrow(() -> new ChatRoomNotFoundException(ExceptionCode.CHAT_ROOM_NOT_FOUND));
+    Message message = new Message(chatRoom, chatMessage.senderNickName(), chatMessage.message());
+    messageRepository.save(message);
+  }
+
+  @Transactional
+  public ChatMessagesResponse findChatMessages(Long chatRoomId) {
+    List<Message> chatMessages = messageRepository.findByChatRoomIdOrderByCreatedAt(
+        chatRoomId);
+    List<ChatMessage> chatMessagesResponse = chatMessages
+        .stream()
+        .map(Message::toChatMessage)
+        .collect(Collectors.toList());
+    return new ChatMessagesResponse(chatMessagesResponse);
+  }
 }

--- a/src/main/java/com/dangdang/server/domain/message/domain/MessageRepository.java
+++ b/src/main/java/com/dangdang/server/domain/message/domain/MessageRepository.java
@@ -1,8 +1,10 @@
 package com.dangdang.server.domain.message.domain;
 
 import com.dangdang.server.domain.message.domain.entity.Message;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
+  List<Message> findByChatRoomIdOrderByCreatedAt(Long chatRoomId);
 }

--- a/src/main/java/com/dangdang/server/domain/message/domain/entity/Message.java
+++ b/src/main/java/com/dangdang/server/domain/message/domain/entity/Message.java
@@ -2,7 +2,7 @@ package com.dangdang.server.domain.message.domain.entity;
 
 import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
 import com.dangdang.server.domain.common.BaseEntity;
-import com.dangdang.server.domain.member.domain.entity.Member;
+import com.dangdang.server.domain.message.dto.ChatMessage;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -24,20 +24,30 @@ public class Message extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "sender_id")
-  private Member sender;
+  @JoinColumn(name = "chat_room_id")
+  private ChatRoom chatRoom;
+
+  @JoinColumn(name = "sender_nickname")
+  private String senderNickName;
 
   @Lob
   @Column(name = "message")
   private String message;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "chat_room_id")
-  private ChatRoom chatRoom;
-
   protected Message() {
 
   }
 
+  public Message(ChatRoom chatRoom, String senderNickName, String message) {
+    this.chatRoom = chatRoom;
+    this.senderNickName = senderNickName;
+    this.message = message;
+  }
 
+  public static ChatMessage toChatMessage(Message message) {
+    return new ChatMessage(
+        message.getChatRoom().getId(),
+        message.getSenderNickName(),
+        message.getMessage());
+  }
 }

--- a/src/main/java/com/dangdang/server/domain/message/dto/ChatMessage.java
+++ b/src/main/java/com/dangdang/server/domain/message/dto/ChatMessage.java
@@ -1,6 +1,6 @@
 package com.dangdang.server.domain.message.dto;
 
-public record ChatMessage(Long chatRoomId, Long senderId, String message) {
+public record ChatMessage(Long chatRoomId, String senderNickName, String message) {
 
 }
 

--- a/src/main/java/com/dangdang/server/domain/message/dto/response/ChatMessagesResponse.java
+++ b/src/main/java/com/dangdang/server/domain/message/dto/response/ChatMessagesResponse.java
@@ -1,0 +1,8 @@
+package com.dangdang.server.domain.message.dto.response;
+
+import com.dangdang.server.domain.message.dto.ChatMessage;
+import java.util.List;
+
+public record ChatMessagesResponse(List<ChatMessage> chatMessages) {
+
+}

--- a/src/main/java/com/dangdang/server/global/exception/ExceptionCode.java
+++ b/src/main/java/com/dangdang/server/global/exception/ExceptionCode.java
@@ -48,7 +48,10 @@ public enum ExceptionCode {
   NO_ACTIVE_TOWN(HttpStatus.INTERNAL_SERVER_ERROR.value(), "활성화된 동네가 없습니다."),
 
   // review
-  REVIEW_WRONG_ACCESS(HttpStatus.BAD_REQUEST.value(), "거래가 완료된 후에만 리뷰 작성이 가능합니다.");
+  REVIEW_WRONG_ACCESS(HttpStatus.BAD_REQUEST.value(), "거래가 완료된 후에만 리뷰 작성이 가능합니다."),
+
+  // chat
+  CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "채팅방을 찾지 못하였습니다");
 
   private final int status;
   private final String message;

--- a/src/test/java/com/dangdang/server/controller/chat/ChatMessageControllerTest.java
+++ b/src/test/java/com/dangdang/server/controller/chat/ChatMessageControllerTest.java
@@ -1,0 +1,111 @@
+package com.dangdang.server.controller.chat;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dangdang.server.domain.chatroom.domain.ChatRoomRepository;
+import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
+import com.dangdang.server.domain.member.domain.MemberRepository;
+import com.dangdang.server.domain.member.domain.entity.Member;
+import com.dangdang.server.domain.message.domain.MessageRepository;
+import com.dangdang.server.domain.message.domain.entity.Message;
+import com.dangdang.server.domain.post.domain.Category;
+import com.dangdang.server.domain.post.domain.PostRepository;
+import com.dangdang.server.domain.post.domain.entity.Post;
+import com.dangdang.server.domain.town.domain.TownRepository;
+import com.dangdang.server.domain.town.domain.entity.Town;
+import com.dangdang.server.global.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@SpringBootTest
+class ChatMessageControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  MemberRepository memberRepository;
+
+  @Autowired
+  TownRepository townRepository;
+
+  @Autowired
+  PostRepository postRepository;
+
+  @Autowired
+  ChatRoomRepository chatRoomRepository;
+
+  @Autowired
+  MessageRepository messageRepository;
+
+  @Autowired
+  JwtTokenProvider jwtTokenProvider;
+
+  @Test
+  @DisplayName("채팅 방 메세지 조회 성공")
+  @Transactional
+  void findChatMessages_success() throws Exception {
+    Member buyer = new Member("01012345677", "buyer");
+    Member seller = new Member("01087654321", "seller");
+    Town sellerTown = new Town("내동네", null, null);
+
+    Post post = new Post("에어팟", "에어팟 팝니다", Category.디지털기기, null,
+        null, null, null,
+        0, false, seller, sellerTown, null, null);
+
+    ChatRoom chatRoom = new ChatRoom(buyer, seller, post);
+
+    Member savedBuyer = memberRepository.save(buyer);
+    memberRepository.save(seller);
+    townRepository.save(sellerTown);
+    postRepository.save(post);
+    ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+
+    Message message1 = new Message(chatRoom, savedBuyer.getNickname(), "안녕하세요 당근당근");
+    Message message2 = new Message(chatRoom, savedBuyer.getNickname(), "에어팟 파나요??");
+
+    messageRepository.save(message1);
+    messageRepository.save(message2);
+
+    String accessToken = "Bearer " + jwtTokenProvider.createAccessToken(savedBuyer.getId());
+
+    // when
+    mockMvc.perform(get("/chat-room/" + savedChatRoom.getId())
+            .header("AccessToken", accessToken)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andDo(
+            document("api/v1/get/chat-room/message",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                    headerWithName("AccessToken").description("Access Token")
+                ),
+                responseFields(
+                    fieldWithPath("chatMessages[]").type(JsonFieldType.ARRAY).description("채팅방 메세지들"),
+                    fieldWithPath("chatMessages[].chatRoomId").description("채팅방 아이디"),
+                    fieldWithPath("chatMessages[].senderNickName").description("메세지 보낸 사람"),
+                    fieldWithPath("chatMessages[].message").description("메세지")
+                )
+            ));
+  }
+}

--- a/src/test/java/com/dangdang/server/controller/chat/ChatRoomControllerTest.java
+++ b/src/test/java/com/dangdang/server/controller/chat/ChatRoomControllerTest.java
@@ -19,6 +19,8 @@ import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
 import com.dangdang.server.domain.chatroom.dto.request.ChatRoomSaveRequest;
 import com.dangdang.server.domain.member.domain.MemberRepository;
 import com.dangdang.server.domain.member.domain.entity.Member;
+import com.dangdang.server.domain.message.domain.MessageRepository;
+import com.dangdang.server.domain.message.domain.entity.Message;
 import com.dangdang.server.domain.post.domain.Category;
 import com.dangdang.server.domain.post.domain.PostRepository;
 import com.dangdang.server.domain.post.domain.entity.Post;
@@ -61,7 +63,11 @@ class ChatRoomControllerTest {
   ChatRoomRepository chatRoomRepository;
 
   @Autowired
+  MessageRepository messageRepository;
+
+  @Autowired
   JwtTokenProvider jwtTokenProvider;
+
 
   @Test
   @DisplayName("채팅 방 생성 성공")
@@ -155,6 +161,16 @@ class ChatRoomControllerTest {
     ChatRoom chatRoom2 = new ChatRoom(buyer2, seller, post);
     ChatRoom chatRoom3 = new ChatRoom(buyer3, seller, post);
 
+
+    Message message1 = new Message(chatRoom1, buyer1.getNickname(), "안녕하세요! 맥북 air 있나요?");
+    Message message2 = new Message(chatRoom2, buyer2.getNickname(), "안녕하세요! 맥북 pro 있나요?");
+    Message message3 = new Message(chatRoom3, buyer3.getNickname(), "안녕하세요! 아이폰 있나요?");
+
+    chatRoom1.getMessageList().add(message1);
+    chatRoom2.getMessageList().add(message2);
+    chatRoom3.getMessageList().add(message3);
+
+
     chatRoomRepository.save(chatRoom1);
     chatRoomRepository.save(chatRoom2);
     chatRoomRepository.save(chatRoom3);
@@ -165,6 +181,7 @@ class ChatRoomControllerTest {
             .header("AccessToken",accessToken)
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
+        .andDo(print())
         .andDo(
             document("api/v1/get/chat-room",
                 preprocessRequest(prettyPrint()),

--- a/src/test/java/com/dangdang/server/controller/memberTown/MemberTownControllerTest.java
+++ b/src/test/java/com/dangdang/server/controller/memberTown/MemberTownControllerTest.java
@@ -71,7 +71,6 @@ class MemberTownControllerTest {
   Member member;
   String accessToken;
 
-
   @BeforeEach
   void setup() {
     member = new Member("01012345678", null, "Albatross");

--- a/src/test/java/com/dangdang/server/domain/chatroom/application/ChatRoomServiceTest.java
+++ b/src/test/java/com/dangdang/server/domain/chatroom/application/ChatRoomServiceTest.java
@@ -9,6 +9,8 @@ import com.dangdang.server.domain.chatroom.dto.request.ChatRoomSaveRequest;
 import com.dangdang.server.domain.chatroom.dto.response.ChatRoomsResponse;
 import com.dangdang.server.domain.member.domain.MemberRepository;
 import com.dangdang.server.domain.member.domain.entity.Member;
+import com.dangdang.server.domain.message.domain.MessageRepository;
+import com.dangdang.server.domain.message.domain.entity.Message;
 import com.dangdang.server.domain.post.domain.Category;
 import com.dangdang.server.domain.post.domain.PostRepository;
 import com.dangdang.server.domain.post.domain.entity.Post;
@@ -39,6 +41,9 @@ class ChatRoomServiceTest {
 
   @Autowired
   PostRepository postRepository;
+
+  @Autowired
+  MessageRepository messageRepository;
 
 
   @Test
@@ -89,12 +94,6 @@ class ChatRoomServiceTest {
   @Test
   @DisplayName("채팅방 조회 성공")
   void findChatRooms_success() {
-    // chatRoom 생성 필요
-    // 1. member 2명 생성 필요
-    // 2. post 생성 필요 -> town 생성 필요
-
-    // 3. buyer 달리해서 ChatRoom 만들기
-
     Member buyer1 = new Member("01012345677", "buyer1");
     Member buyer2 = new Member("01012345678", "buyer2");
     Member buyer3 = new Member("01012345679", "buyer3");
@@ -116,9 +115,20 @@ class ChatRoomServiceTest {
     ChatRoom chatRoom2 = new ChatRoom(buyer2, seller, post);
     ChatRoom chatRoom3 = new ChatRoom(buyer3, seller, post);
 
+
+    Message message1 = new Message(chatRoom1, buyer1.getNickname(), "안녕하세요! 맥북 air 있나요?");
+    Message message2 = new Message(chatRoom2, buyer2.getNickname(), "안녕하세요! 맥북 pro 있나요?");
+    Message message3 = new Message(chatRoom3, buyer3.getNickname(), "안녕하세요! 아이폰 있나요?");
+
+    chatRoom1.getMessageList().add(message1);
+    chatRoom2.getMessageList().add(message2);
+    chatRoom3.getMessageList().add(message3);
+
+
     chatRoomRepository.save(chatRoom1);
     chatRoomRepository.save(chatRoom2);
     chatRoomRepository.save(chatRoom3);
+
 
     // when
     ChatRoomsResponse chatRoomsResponse = chatRoomService.findChatRooms(savedSeller.getId());

--- a/src/test/java/com/dangdang/server/domain/memberTown/application/MemberTownServiceTest.java
+++ b/src/test/java/com/dangdang/server/domain/memberTown/application/MemberTownServiceTest.java
@@ -44,11 +44,13 @@ class MemberTownServiceTest {
   MemberTownService memberTownService;
 
   Member member;
+  Long memberId;
 
   @BeforeEach
   void setup() {
     member = new Member("01012345678", null, "Albatross");
-    memberRepository.save(member);
+    Member savedMember = memberRepository.save(member);
+    memberId = savedMember.getId();
   }
 
   @AfterEach
@@ -69,8 +71,7 @@ class MemberTownServiceTest {
     MemberTownRequest memberTownRequest = new MemberTownRequest("삼성1동");
 
     // when
-    memberTownService.createMemberTown(memberTownRequest,
-        member);
+    memberTownService.createMemberTown(memberTownRequest, memberId);
 
     // then
     // memberTown list size 가 2개인지 확인, 상태가 변경되었는지 확인
@@ -89,7 +90,7 @@ class MemberTownServiceTest {
     MemberTownRequest memberTownRequest = new MemberTownRequest("삼성1동");
 
     // when, then
-    assertThatThrownBy(() -> memberTownService.createMemberTown(memberTownRequest, member))
+    assertThatThrownBy(() -> memberTownService.createMemberTown(memberTownRequest, memberId))
         .isInstanceOf(NotAppropriateCountException.class);
   }
 
@@ -110,11 +111,11 @@ class MemberTownServiceTest {
     MemberTownRequest memberTownRequest = new MemberTownRequest("삼성1동");
 
     // when
-    memberTownService.deleteMemberTown(memberTownRequest, member);
+    memberTownService.deleteMemberTown(memberTownRequest, memberId);
 
     // then
     // size 는 1이고 삼성 2동이며 Active 상태
-    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(member.getId());
+    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(memberId);
     assertThat(memberTownList.size()).isEqualTo(1);
     assertThat(memberTownList.get(0).getTown().getName()).isEqualTo("삼성2동");
     assertThat(memberTownList.get(0).getStatus()).isEqualTo(StatusType.ACTIVE);
@@ -137,10 +138,10 @@ class MemberTownServiceTest {
     MemberTownRequest memberTownRequest = new MemberTownRequest("삼성2동");
 
     // when
-    memberTownService.deleteMemberTown(memberTownRequest, member);
+    memberTownService.deleteMemberTown(memberTownRequest, memberId);
 
     // then
-    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(member.getId());
+    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(memberId);
     assertThat(memberTownList.size()).isEqualTo(1);
     assertThat(memberTownList.get(0).getTown().getName()).isEqualTo("삼성1동");
     assertThat(memberTownList.get(0).getStatus()).isEqualTo(StatusType.ACTIVE);
@@ -153,7 +154,7 @@ class MemberTownServiceTest {
     MemberTownRequest memberTownRequest = new MemberTownRequest("삼성1동");
 
     // then, given
-    assertThatThrownBy(() -> memberTownService.deleteMemberTown(memberTownRequest, member))
+    assertThatThrownBy(() -> memberTownService.deleteMemberTown(memberTownRequest, memberId))
         .isInstanceOf(NotAppropriateCountException.class);
   }
 
@@ -174,7 +175,7 @@ class MemberTownServiceTest {
     MemberTownRequest memberTownRequest = new MemberTownRequest("삼성7동");
 
     // then, given
-    assertThatThrownBy(() -> memberTownService.deleteMemberTown(memberTownRequest, member))
+    assertThatThrownBy(() -> memberTownService.deleteMemberTown(memberTownRequest, memberId))
         .isInstanceOf(MemberTownNotFoundException.class);
   }
 
@@ -196,11 +197,11 @@ class MemberTownServiceTest {
     MemberTownRequest memberTownRequest = new MemberTownRequest("삼성1동");
 
     // when
-    memberTownService.changeActiveMemberTown(memberTownRequest, member);
+    memberTownService.changeActiveMemberTown(memberTownRequest, memberId);
 
     // then
     // 삼성 1동 Active, 삼성 2동 Inactive
-    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(member.getId());
+    List<MemberTown> memberTownList = memberTownRepository.findByMemberId(memberId);
     assertThat(memberTownList.get(0).getStatus()).isEqualTo(StatusType.ACTIVE);
     assertThat(memberTownList.get(1).getStatus()).isEqualTo(StatusType.INACTIVE);
   }
@@ -217,7 +218,7 @@ class MemberTownServiceTest {
     MemberTownRequest memberTownRequest = new MemberTownRequest("삼성2동");
 
     // when, then
-    assertThatThrownBy(() -> memberTownService.changeActiveMemberTown(memberTownRequest, member))
+    assertThatThrownBy(() -> memberTownService.changeActiveMemberTown(memberTownRequest, memberId))
         .isInstanceOf(NotAppropriateCountException.class);
   }
 
@@ -233,7 +234,7 @@ class MemberTownServiceTest {
     MemberTownRangeRequest memberTownRangeRequest = new MemberTownRangeRequest("삼성1동", 3);
 
     // when
-    memberTownService.changeMemberTownRange(memberTownRangeRequest, member);
+    memberTownService.changeMemberTownRange(memberTownRangeRequest, memberId);
 
     // then
     // range 가 변경 되었는지 확인
@@ -257,7 +258,7 @@ class MemberTownServiceTest {
 
     // when, then
     assertThatThrownBy(
-        () -> memberTownService.changeMemberTownRange(memberTownRangeRequest, member))
+        () -> memberTownService.changeMemberTownRange(memberTownRangeRequest, memberId))
         .isInstanceOf(MemberTownNotFoundException.class);
   }
 
@@ -275,7 +276,7 @@ class MemberTownServiceTest {
 
     // when, then
     assertThatThrownBy(
-        () -> memberTownService.changeMemberTownRange(memberTownRangeRequest, member))
+        () -> memberTownService.changeMemberTownRange(memberTownRangeRequest, memberId))
         .isInstanceOf(NotAppropriateRangeException.class);
   }
 
@@ -293,7 +294,7 @@ class MemberTownServiceTest {
 
     // when
     MemberTownCertifyResponse memberTownCertifyResponse = memberTownService.certifyMemberTown(
-        memberTownCertifyRequest, member);
+        memberTownCertifyRequest, memberId);
 
     // then
     assertThat(memberTownCertifyResponse.isCertified()).isEqualTo(true);
@@ -314,7 +315,7 @@ class MemberTownServiceTest {
 
     // when
     MemberTownCertifyResponse memberTownCertifyResponse = memberTownService.certifyMemberTown(
-        memberTownCertifyRequest, member);
+        memberTownCertifyRequest, memberId);
 
     // then
     assertThat(memberTownCertifyResponse.isCertified()).isEqualTo(false);
@@ -335,7 +336,7 @@ class MemberTownServiceTest {
         BigDecimal.valueOf(127.0738380000), BigDecimal.valueOf(37.6248740000));
 
     // when, then
-    assertThatThrownBy(() -> memberTownService.certifyMemberTown(memberTownCertifyRequest, member))
+    assertThatThrownBy(() -> memberTownService.certifyMemberTown(memberTownCertifyRequest, memberId))
         .isInstanceOf(MemberTownNotFoundException.class);
   }
 }

--- a/src/test/java/com/dangdang/server/domain/memberTown/application/MemberTownServiceUnitTest.java
+++ b/src/test/java/com/dangdang/server/domain/memberTown/application/MemberTownServiceUnitTest.java
@@ -33,7 +33,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-
 class MemberTownServiceUnitTest {
 
   @InjectMocks
@@ -67,7 +66,7 @@ class MemberTownServiceUnitTest {
 
     // when
     MemberTownResponse memberTownResponse = memberTownService.createMemberTown(memberTownRequest,
-        member);
+        1L);
 
     // then
     assertThat(memberTownResponse.townName()).isEqualTo("공릉2동");
@@ -88,7 +87,7 @@ class MemberTownServiceUnitTest {
         .thenReturn(Collections.emptyList());
 
     // when, then
-    assertThatThrownBy(() -> memberTownService.createMemberTown(memberTownRequest, member))
+    assertThatThrownBy(() -> memberTownService.createMemberTown(memberTownRequest, 1L))
         .isInstanceOf(NotAppropriateCountException.class);
   }
 
@@ -103,7 +102,7 @@ class MemberTownServiceUnitTest {
     when(townRepository.findByName(any())).thenReturn(Optional.empty());
 
     // when, then
-    assertThatThrownBy(() -> memberTownService.createMemberTown(memberTownRequest, member))
+    assertThatThrownBy(() -> memberTownService.createMemberTown(memberTownRequest, 1L))
         .isInstanceOf(TownNotFoundException.class);
   }
 
@@ -123,7 +122,7 @@ class MemberTownServiceUnitTest {
     when(memberRepository.findById(any())).thenReturn(Optional.empty());
 
     // when, then
-    assertThatThrownBy(() -> memberTownService.createMemberTown(memberTownRequest, member))
+    assertThatThrownBy(() -> memberTownService.createMemberTown(memberTownRequest, 1L))
         .isInstanceOf(MemberNotFoundException.class);
   }
 
@@ -141,7 +140,7 @@ class MemberTownServiceUnitTest {
             List.of(new MemberTown(member, existingTown1), new MemberTown(member, existingTown2)));
 
     // when
-    memberTownService.deleteMemberTown(memberTownRequest, member);
+    memberTownService.deleteMemberTown(memberTownRequest, 1L);
 
     // then
     verify(memberTownRepository).delete(any());
@@ -159,7 +158,7 @@ class MemberTownServiceUnitTest {
         .thenReturn(List.of(new MemberTown(member, existingTown1)));
 
     // when, then
-    assertThatThrownBy(() -> memberTownService.deleteMemberTown(memberTownRequest, member))
+    assertThatThrownBy(() -> memberTownService.deleteMemberTown(memberTownRequest, 1L))
         .isInstanceOf(NotAppropriateCountException.class);
   }
 
@@ -177,7 +176,7 @@ class MemberTownServiceUnitTest {
             List.of(new MemberTown(member, existingTown1), new MemberTown(member, existingTown2)));
 
     // when, then
-    assertThatThrownBy(() -> memberTownService.deleteMemberTown(memberTownRequest, member))
+    assertThatThrownBy(() -> memberTownService.deleteMemberTown(memberTownRequest, 1L))
         .isInstanceOf(MemberTownNotFoundException.class);
   }
 
@@ -195,8 +194,8 @@ class MemberTownServiceUnitTest {
             List.of(new MemberTown(member, existingTown1), new MemberTown(member, existingTown2)));
 
     // when
-    MemberTownResponse memberTownResponse = memberTownService.changeActiveMemberTown(
-        memberTownRequest, member);
+    MemberTownResponse memberTownResponse = memberTownService
+        .changeActiveMemberTown(memberTownRequest, 1L);
 
     // then
     assertThat(memberTownResponse.townName()).isEqualTo("공릉1동");
@@ -214,7 +213,7 @@ class MemberTownServiceUnitTest {
         .thenReturn(List.of(new MemberTown(member, existingTown1)));
 
     // when, then
-    assertThatThrownBy(() -> memberTownService.changeActiveMemberTown(memberTownRequest, member))
+    assertThatThrownBy(() -> memberTownService.changeActiveMemberTown(memberTownRequest, 1L))
         .isInstanceOf(NotAppropriateCountException.class);
   }
 
@@ -233,7 +232,7 @@ class MemberTownServiceUnitTest {
 
     // when
     MemberTownRangeResponse memberTownRangeResponse = memberTownService.changeMemberTownRange(
-        memberTownRangeRequest, existingMember);
+        memberTownRangeRequest, 1L);
 
     // then
     assertThat(memberTownRangeResponse).usingRecursiveComparison()
@@ -257,7 +256,7 @@ class MemberTownServiceUnitTest {
 
     // when, then
     assertThatThrownBy(
-        () -> memberTownService.changeMemberTownRange(memberTownRangeRequest, existingMember))
+        () -> memberTownService.changeMemberTownRange(memberTownRangeRequest, 1L))
         .isInstanceOf(MemberTownNotFoundException.class);
   }
 }

--- a/src/test/java/com/dangdang/server/domain/message/application/ChatMessageServiceTest.java
+++ b/src/test/java/com/dangdang/server/domain/message/application/ChatMessageServiceTest.java
@@ -1,0 +1,93 @@
+package com.dangdang.server.domain.message.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.dangdang.server.domain.chatroom.domain.ChatRoomRepository;
+import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
+import com.dangdang.server.domain.member.domain.MemberRepository;
+import com.dangdang.server.domain.member.domain.entity.Member;
+import com.dangdang.server.domain.message.domain.MessageRepository;
+import com.dangdang.server.domain.message.domain.entity.Message;
+import com.dangdang.server.domain.message.dto.ChatMessage;
+import com.dangdang.server.domain.post.domain.Category;
+import com.dangdang.server.domain.post.domain.PostRepository;
+import com.dangdang.server.domain.post.domain.entity.Post;
+import com.dangdang.server.domain.town.domain.TownRepository;
+import com.dangdang.server.domain.town.domain.entity.Town;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@SpringBootTest
+class ChatMessageServiceTest {
+
+  @Autowired
+  ChatMessageService chatMessageService;
+
+  @Autowired
+  MemberRepository memberRepository;
+
+  @Autowired
+  TownRepository townRepository;
+
+  @Autowired
+  PostRepository postRepository;
+
+  @Autowired
+  ChatRoomRepository chatRoomRepository;
+
+  @Autowired
+  MessageRepository messageRepository;
+
+
+  @Test
+  @DisplayName("채팅 메세지가 성공적으로 저장")
+  @Transactional
+  void saveChatMessage() {
+    Member buyer = new Member("01012345677", "buyer");
+    Member seller = new Member("01087654321", "seller");
+    Town sellerTown = new Town("내동네", null, null);
+
+    Post post = new Post("에어팟", "에어팟 팝니다", Category.디지털기기, null,
+        null, null, null,
+        0, false, seller, sellerTown, null, null);
+
+    ChatRoom chatRoom = new ChatRoom(buyer, seller, post);
+
+    Member savedBuyer = memberRepository.save(buyer);
+    memberRepository.save(seller);
+    townRepository.save(sellerTown);
+    postRepository.save(post);
+    ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+
+    ChatMessage chatMessage1 = new ChatMessage(savedChatRoom.getId(), savedBuyer.getNickname(), "안녕하세요 당근당근");
+    ChatMessage chatMessage2 = new ChatMessage(savedChatRoom.getId(), savedBuyer.getNickname(), "에어팟 팔렸나요?");
+
+    // when
+    chatMessageService.saveChatMessage(chatMessage1);
+    chatMessageService.saveChatMessage(chatMessage2);
+
+    // then
+    List<Message> messages = messageRepository.findByChatRoomIdOrderByCreatedAt(savedChatRoom.getId());
+    assertThat(messages.size()).isEqualTo(2);
+    for (Message message : messages) {
+      System.out.println(message.getMessage());
+    }
+
+
+
+  }
+  @Test
+  void print() {
+    ChatRoom chatRoom = chatRoomRepository.findById(49L).get();
+    List<Message> messageList = chatRoom.getMessageList();
+    System.out.println(messageList.size());
+    for (Message message : messageList) {
+      System.out.println(message.getMessage());
+    }
+  }
+}

--- a/src/test/java/com/dangdang/server/domain/message/application/ChatMessageServiceTest.java
+++ b/src/test/java/com/dangdang/server/domain/message/application/ChatMessageServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.dangdang.server.domain.chatroom.domain.ChatRoomRepository;
 import com.dangdang.server.domain.chatroom.domain.entity.ChatRoom;
+import com.dangdang.server.domain.chatroom.exception.ChatRoomNotFoundException;
 import com.dangdang.server.domain.member.domain.MemberRepository;
 import com.dangdang.server.domain.member.domain.entity.Member;
 import com.dangdang.server.domain.message.domain.MessageRepository;
@@ -20,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-
 
 @SpringBootTest
 class ChatMessageServiceTest {
@@ -67,27 +67,42 @@ class ChatMessageServiceTest {
     ChatMessage chatMessage1 = new ChatMessage(savedChatRoom.getId(), savedBuyer.getNickname(), "안녕하세요 당근당근");
     ChatMessage chatMessage2 = new ChatMessage(savedChatRoom.getId(), savedBuyer.getNickname(), "에어팟 팔렸나요?");
 
-    // when
     chatMessageService.saveChatMessage(chatMessage1);
     chatMessageService.saveChatMessage(chatMessage2);
 
-    // then
     List<Message> messages = messageRepository.findByChatRoomIdOrderByCreatedAt(savedChatRoom.getId());
     assertThat(messages.size()).isEqualTo(2);
     for (Message message : messages) {
       System.out.println(message.getMessage());
     }
-
-
-
   }
+
   @Test
-  void print() {
-    ChatRoom chatRoom = chatRoomRepository.findById(49L).get();
-    List<Message> messageList = chatRoom.getMessageList();
-    System.out.println(messageList.size());
-    for (Message message : messageList) {
-      System.out.println(message.getMessage());
-    }
+  @DisplayName("채팅 메세지 저장 실패 - 채팅방을 찾을 수 없는 경우")
+  @Transactional
+  void saveChatMessage_failByNotFoundChatRoom() {
+    Member buyer = new Member("01012345677", "buyer");
+    Member seller = new Member("01087654321", "seller");
+    Town sellerTown = new Town("내동네", null, null);
+
+    Post post = new Post("에어팟", "에어팟 팝니다", Category.디지털기기, null,
+        null, null, null,
+        0, false, seller, sellerTown, null, null);
+
+    ChatRoom chatRoom = new ChatRoom(buyer, seller, post);
+
+    Member savedBuyer = memberRepository.save(buyer);
+    memberRepository.save(seller);
+    townRepository.save(sellerTown);
+    postRepository.save(post);
+    chatRoomRepository.save(chatRoom);
+
+    ChatMessage chatMessage = new ChatMessage(0L, savedBuyer.getNickname(), "안녕하세요 당근당근");
+
+    assertThatThrownBy(() -> chatMessageService.saveChatMessage(chatMessage))
+        .isInstanceOf(ChatRoomNotFoundException.class);
+
+
   }
+
 }


### PR DESCRIPTION
### 변경 내용 요약
채팅방에서 채팅의 저장과 조회에 대해 코드 구현하였습니다

### 작업한 내용
**<채팅 조회>**
GET api/v1/chat-room/{room_id} 를 통해 상세 채팅방에서의 이전 채팅 내용을 시간 순서로 출력하도록 하였습니다
채팅이 들어올 때 그 내용을 Message 엔티티로 전환해서 DB에 저장하도록 하였습니다

### 관련 링크
- [TRYC-73](https://cloudwi.atlassian.net/browse/TRYC-73) 

### 기타 사항
테스트 코드는 성공에  경우에 대해서만 작성하였습니다


[TRYC-73]: https://cloudwi.atlassian.net/browse/TRYC-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ